### PR TITLE
Forward compatibility with pyang 2.x and tests for leafref in grouping

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2019 128 Technology, Inc.
+
+"""
+This file is for some reason required for pytest-cov to report correctly
+"""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,57 @@
+# Copyright 2019 128 Technology, Inc.
+
+import os
+import contextlib
+import sys
+import runpy
+import pytest
+import io
+
+import pyang
+from lxml import etree
+
+from yinsolidated.plugin import plugin
+
+YINSOLIDATED_PLUGIN_DIRECTORY = os.path.dirname(plugin.__file__)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--pyang-path", action="store",
+                     help="path to pyang executable")
+
+
+@pytest.fixture(scope='session')
+def consolidated_model(request):
+    test_file_dir = os.path.dirname(os.path.realpath(__file__))
+    modules_dir = os.path.join(test_file_dir, 'modules')
+    main_module = os.path.join(modules_dir, 'test-module.yang')
+    augmenting_module = os.path.join(modules_dir, 'augmenting-module.yang')
+
+    pyang_args = [
+        '--verbose',
+        '-W', 'error',
+        '-f', 'yinsolidated',
+        '-p', modules_dir,
+    ]
+
+    if pyang.__version__ < '1.7.2':
+        pyang_args.extend(['--plugindir', YINSOLIDATED_PLUGIN_DIRECTORY])
+
+    pyang_args.extend([main_module, augmenting_module])
+    pyang_path = request.config.getoption("--pyang-path")
+
+    sys.argv = [pyang_path] + pyang_args
+
+    stream = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(stream):
+            runpy.run_path(pyang_path, run_name="__main__")
+    except SystemExit as err:
+        if err.code != 0:
+            raise
+
+    try:
+        return etree.fromstring(stream.getvalue().encode("utf-8"))
+    except etree.XMLSyntaxError:
+        print(stream.getvalue(), file=sys.stderr)
+        raise

--- a/test/modules/test-module.yang
+++ b/test/modules/test-module.yang
@@ -13,13 +13,12 @@ module test-module {
     description
         "Test module containing an exhaustive set of possible YANG statements";
 
+    reference "RFC 6020";
+
     revision 2016-04-22 {
         description
             "Initial revision";
     }
-
-    // TODO(athompson): bug in pyang? this should be allowed
-    // reference "RFC 6020";
 
     // TODO(athompson): add deviation statement
 
@@ -163,7 +162,7 @@ module test-module {
         }
 
         uses nested-grouping {
-            when "grouped-leaf != 'nonsense'";
+            when "../grouped-leaf != 'nonsense'";
         }
     }
 
@@ -266,7 +265,7 @@ module test-module {
 
             uses simple-test-grouping;
 
-            when "../root-leaf != 'nonsense'";
+            when "root-leaf != 'nonsense'";
         }
 
         config true;
@@ -297,7 +296,7 @@ module test-module {
 
         status "obsolete";
 
-        when "../root-leaf != 'nonsense'";
+        when "root-leaf != 'nonsense'";
     }
 
     container root-container {
@@ -469,7 +468,7 @@ module test-module {
             description "A leaf in a grouping with a refined description";
         }
 
-        when "../root-leaf != 'nonsense'";
+        when "root-leaf != 'nonsense'";
     }
 
     leaf leaf-with-typedef {

--- a/test/modules/test-module.yang
+++ b/test/modules/test-module.yang
@@ -138,6 +138,18 @@ module test-module {
             type string;
         }
 
+        leaf-list grouped-leaf-list-ref {
+            type leafref {
+                path "../root-leaf";
+            }
+        }
+
+        leaf grouped-leaf-ref {
+            type leafref {
+                path "../root-leaf";
+            }
+        }
+
         list grouped-list {
             config false;
         }

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -4,12 +4,17 @@
 
 from __future__ import unicode_literals
 
-import logging
 import os
+import subprocess
 
+import pyang
 import pytest
 from lxml import doctestcompare, etree
 
+from yinsolidated.plugin import plugin
+
+
+YINSOLIDATED_PLUGIN_DIRECTORY = os.path.dirname(plugin.__file__)
 
 YIN_NAMESPACE = 'urn:ietf:params:xml:ns:yang:yin:1'
 TEST_NAMESPACE = 'urn:xml:ns:test'
@@ -20,7 +25,29 @@ NSMAP = {
     'aug': AUGMENTING_NAMESPACE
 }
 
-logging.basicConfig(format="%(message)s", level=logging.DEBUG)
+
+@pytest.fixture(scope='module')
+def consolidated_model():
+    test_file_dir = os.path.dirname(os.path.realpath(__file__))
+    modules_dir = os.path.join(test_file_dir, 'modules')
+    main_module = os.path.join(modules_dir, 'test-module.yang')
+    augmenting_module = os.path.join(modules_dir, 'augmenting-module.yang')
+
+    pyang_command = [
+        'pyang',
+        '-f', 'yinsolidated',
+        '-p', modules_dir,
+    ]
+
+    if pyang.__version__ < '1.7.2':
+        pyang_command.extend(['--plugindir', YINSOLIDATED_PLUGIN_DIRECTORY])
+
+    pyang_command.extend([main_module, augmenting_module])
+
+    consolidated_model_xml = subprocess.check_output(pyang_command)
+
+    return etree.fromstring(consolidated_model_xml)
+
 
 _XML_CHECKER = doctestcompare.LXMLOutputChecker()
 

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -558,7 +558,6 @@ class TestList(object):
             </list>
             """.format(**NSMAP)
 
-        print(actual_xml.decode())
         assert_xml_equal(expected_xml, actual_xml)
 
 

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -640,6 +640,7 @@ class TestUses(object):
 
         assert_xml_equal(expected_xml, actual_xml)
 
+    @pytest.mark.skip("https://github.com/mbj4668/pyang/issues/527")
     def test_grouped_leaf_list_ref(self, consolidated_model):
         grouped_leaf_list_elem = consolidated_model.find(
             'yin:leaf-list[@name="grouped-leaf-list-ref"]',
@@ -660,6 +661,7 @@ class TestUses(object):
 
         assert_xml_equal(expected_xml, actual_xml)
 
+    @pytest.mark.skip("https://github.com/mbj4668/pyang/issues/527")
     def test_grouped_leaf_ref(self, consolidated_model):
         grouped_leaf_list_elem = consolidated_model.find(
             'yin:leaf[@name="grouped-leaf-ref"]',

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -4,17 +4,9 @@
 
 from __future__ import unicode_literals
 
-import os
-import subprocess
-
-import pyang
 import pytest
 from lxml import doctestcompare, etree
 
-from yinsolidated.plugin import plugin
-
-
-YINSOLIDATED_PLUGIN_DIRECTORY = os.path.dirname(plugin.__file__)
 
 YIN_NAMESPACE = 'urn:ietf:params:xml:ns:yang:yin:1'
 TEST_NAMESPACE = 'urn:xml:ns:test'
@@ -24,29 +16,6 @@ NSMAP = {
     'test': TEST_NAMESPACE,
     'aug': AUGMENTING_NAMESPACE
 }
-
-
-@pytest.fixture(scope='module')
-def consolidated_model():
-    test_file_dir = os.path.dirname(os.path.realpath(__file__))
-    modules_dir = os.path.join(test_file_dir, 'modules')
-    main_module = os.path.join(modules_dir, 'test-module.yang')
-    augmenting_module = os.path.join(modules_dir, 'augmenting-module.yang')
-
-    pyang_command = [
-        'pyang',
-        '-f', 'yinsolidated',
-        '-p', modules_dir,
-    ]
-
-    if pyang.__version__ < '1.7.2':
-        pyang_command.extend(['--plugindir', YINSOLIDATED_PLUGIN_DIRECTORY])
-
-    pyang_command.extend([main_module, augmenting_module])
-
-    consolidated_model_xml = subprocess.check_output(pyang_command)
-
-    return etree.fromstring(consolidated_model_xml)
 
 
 _XML_CHECKER = doctestcompare.LXMLOutputChecker()
@@ -372,7 +341,7 @@ class TestChoice(object):
                     <text>RFC 6020</text>
                 </reference>
                 <status value="obsolete"/>
-                <when condition="../root-leaf != 'nonsense'"/>
+                <when condition="root-leaf != 'nonsense'"/>
                 <case name="anyxml-case">
                     <anyxml name="anyxml-case"/>
                 </case>
@@ -385,7 +354,7 @@ class TestChoice(object):
                         <text>RFC 6020</text>
                     </reference>
                     <status value="current"/>
-                    <when condition="../root-leaf != 'nonsense'"/>
+                    <when condition="root-leaf != 'nonsense'"/>
                     <anyxml name="anyxml-within-case"/>
                     <choice name="choice-within-case"/>
                     <container name="container-within-case"/>
@@ -589,6 +558,7 @@ class TestList(object):
             </list>
             """.format(**NSMAP)
 
+        print(actual_xml.decode())
         assert_xml_equal(expected_xml, actual_xml)
 
 
@@ -602,7 +572,7 @@ class TestUses(object):
         expected_xml = """
             <choice xmlns="{yin}" name="grouped-choice">
                 <if-feature name="test-feature"/>
-                <when condition="../root-leaf != 'nonsense'"
+                <when condition="root-leaf != 'nonsense'"
                       context-node="parent"/>
             </choice>
             """.format(**NSMAP)
@@ -617,7 +587,7 @@ class TestUses(object):
         expected_xml = """
             <container xmlns="{yin}" name="grouped-container">
                 <if-feature name="test-feature"/>
-                <when condition="../root-leaf != 'nonsense'"
+                <when condition="root-leaf != 'nonsense'"
                       context-node="parent"/>
                 <anyxml name="augmented-in-uses-anyxml">
                     <when condition="../grouped-leaf != 'nonsense'"
@@ -644,7 +614,7 @@ class TestUses(object):
                     <text>A leaf in a grouping with a refined description</text>
                 </description>
                 <if-feature name="test-feature"/>
-                <when condition="../root-leaf != 'nonsense'"
+                <when condition="root-leaf != 'nonsense'"
                       context-node="parent"/>
             </leaf>
             """.format(**NSMAP)  # nopep8
@@ -660,7 +630,7 @@ class TestUses(object):
             <leaf-list xmlns="{yin}" name="grouped-leaf-list">
                 <type name="string"/>
                 <if-feature name="test-feature"/>
-                <when condition="../root-leaf != 'nonsense'"
+                <when condition="root-leaf != 'nonsense'"
                       context-node="parent"/>
             </leaf-list>
             """.format(**NSMAP)
@@ -718,7 +688,7 @@ class TestUses(object):
             <list xmlns="{yin}" name="grouped-list">
                 <config value="false"/>
                 <if-feature name="test-feature"/>
-                <when condition="../root-leaf != 'nonsense'"
+                <when condition="root-leaf != 'nonsense'"
                       context-node="parent"/>
             </list>
             """.format(**NSMAP)
@@ -733,9 +703,9 @@ class TestUses(object):
         expected_xml = """
             <anyxml xmlns="{yin}" name="nested-grouped-anyxml">
                 <if-feature name="test-feature"/>
-                <when condition="../root-leaf != 'nonsense'"
+                <when condition="root-leaf != 'nonsense'"
                       context-node="parent"/>
-                <when condition="grouped-leaf != 'nonsense'"
+                <when condition="../grouped-leaf != 'nonsense'"
                       context-node="parent"/>
             </anyxml>
             """.format(**NSMAP)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
 envlist =
+    clean-coverage,
     {py27,py34,py35,py36}-pyang{16,17,171,172,173,175,202,21},
     pep8,
     pylint
+
+[testenv:clean-coverage]
+deps = coverage
+skip_install = true
+commands = coverage erase
 
 [testenv]
 deps =
@@ -13,18 +19,19 @@ deps =
     pyang172: pyang == 1.7.2
     pyang173: pyang == 1.7.3
     pyang175: pyang == 1.7.5
-    pyang175: pyang == 1.7.8
+    pyang178: pyang == 1.7.8
     pyang202: pyang == 2.0.2
     pyang21: pyang == 2.1
     pytest == 4.6.6
-    pytest-cov == 2.5.1
+    pytest-cov == 2.8.1
 
 commands =
-    py.test \
-        --pyang-path={envbindir}/pyang \
-        --cov=yinsolidated.parser --cov-report=term-missing \
-        -v {posargs} \
-        test
+    pytest -v {posargs} \
+    --pyang-path={envbindir}/pyang \
+    --cov=./yinsolidated \
+    --cov-report=term-missing \
+    --cov-append \
+    test
 
 [testenv:pep8]
 deps =
@@ -49,3 +56,20 @@ commands =
 [travis]
 python =
     3.6: py36, pep8, pylint
+
+[pytest]
+addopts =
+    --strict-markers
+
+markers =
+    pylint: Marker for the pytest-pylint plugin
+    pep8: marker for the pytest-pep8 plugin
+
+; Warnings that we don't want to see.
+; Why use filterwarnings: https://nedbatchelder.com/blog/201810/why_warnings_is_mysterious.html
+; If we upgrade all of the linting dependencies, some of these should go away
+filterwarnings =
+    ignore::PendingDeprecationWarning:astroid
+    ignore::DeprecationWarning:astroid
+    ignore::PendingDeprecationWarning:pylint
+    ignore::DeprecationWarning:pylint

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-pyang{16,17,171,172,173},
+    {py27,py34,py35,py36}-pyang{16,17,171,172,173,175,128},
     pep8,
     pylint
 
@@ -12,11 +12,14 @@ deps =
     pyang171: pyang == 1.7.1
     pyang172: pyang == 1.7.2
     pyang173: pyang == 1.7.3
-    pytest == 3.2.3
+    pyang175: pyang == 1.7.5
+    pytest == 5.3.0
     pytest-cov == 2.5.1
 
 commands =
+    pyang128: pip install --editable /Users/ichamberlain/Documents/thirdparty/pyang
     py.test \
+        --pyang-path={envbindir}/pyang \
         --cov=yinsolidated.parser --cov-report=term-missing \
         -v {posargs} \
         test

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 commands =
     pytest -v {posargs} \
     --pyang-path={envbindir}/pyang \
-    --cov=./yinsolidated \
+    --cov=yinsolidated \
     --cov-report=term-missing \
     --cov-append \
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-pyang{16,17,171,172,173,175,128},
+    {py27,py34,py35,py36}-pyang{16,17,171,172,173,175,202,21},
     pep8,
     pylint
 
@@ -13,11 +13,13 @@ deps =
     pyang172: pyang == 1.7.2
     pyang173: pyang == 1.7.3
     pyang175: pyang == 1.7.5
+    pyang175: pyang == 1.7.8
+    pyang202: pyang == 2.0.2
+    pyang21: pyang == 2.1
     pytest == 5.3.0
     pytest-cov == 2.5.1
 
 commands =
-    pyang128: pip install --editable /Users/ichamberlain/Documents/thirdparty/pyang
     py.test \
         --pyang-path={envbindir}/pyang \
         --cov=yinsolidated.parser --cov-report=term-missing \
@@ -26,7 +28,7 @@ commands =
 
 [testenv:pep8]
 deps =
-    pyang == 1.7.3
+    pyang == 2.1
     pytest == 3.2.3
     pytest-pep8 == 1.0.6
 
@@ -35,7 +37,7 @@ commands =
 
 [testenv:pylint]
 deps =
-    pyang == 1.7.3
+    pyang == 2.1
     pytest == 3.2.3
     pytest-pylint == 0.12.3
     pylint < 2.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pyang175: pyang == 1.7.8
     pyang202: pyang == 2.0.2
     pyang21: pyang == 2.1
-    pytest == 5.3.0
+    pytest == 4.6.6
     pytest-cov == 2.5.1
 
 commands =
@@ -29,7 +29,7 @@ commands =
 [testenv:pep8]
 deps =
     pyang == 2.1
-    pytest == 3.2.3
+    pytest == 4.6.6
     pytest-pep8 == 1.0.6
 
 commands =
@@ -38,7 +38,7 @@ commands =
 [testenv:pylint]
 deps =
     pyang == 2.1
-    pytest == 3.2.3
+    pytest == 4.6.6
     pytest-pylint == 0.12.3
     pylint < 2.0
 

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = '1.4.1'
+__version__ = '1.4.0'

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/yinsolidated/plugin/plugin.py
+++ b/yinsolidated/plugin/plugin.py
@@ -13,16 +13,17 @@ NOTE: the main module MUST be passed as the first positional argument
 
 from __future__ import unicode_literals
 
+import io
+import contextlib
+import logging
+
 from lxml import etree
-from pyang import (
-    plugin,
-    statements,
-    syntax,
-    yin_parser,
-    __version__ as pyang_version
-)
+from pyang import __version__ as pyang_version
+from pyang import plugin, statements, syntax, yin_parser
 
 from yinsolidated import _common
+
+LOG = logging.getLogger(__name__)
 
 
 _EXTRA_PYANG_DATA_KEYWORDS = [
@@ -46,6 +47,15 @@ _DATA_KEYWORDS = (
 )
 
 
+@contextlib.contextmanager
+def log_print(header="Redirected stdout:"):
+    msgbuf = io.StringIO()
+    with contextlib.redirect_stdout(msgbuf):
+        print(header)
+        yield
+    LOG.debug(msgbuf.getvalue())
+
+
 def pyang_plugin_init():
     """Required function definition for Pyang to register the plugin"""
 
@@ -63,8 +73,8 @@ class ConsolidatedModelPlugin(plugin.PyangPlugin):
         self.multiple_modules = True
         formats['yinsolidated'] = self
 
-    def emit(self, _, modules, output):
-        model = _build_consolidated_model(modules)
+    def emit(self, ctx, modules, output):
+        model = _build_consolidated_model(ctx, modules)
 
         document = etree.tostring(
             model,
@@ -75,7 +85,7 @@ class ConsolidatedModelPlugin(plugin.PyangPlugin):
         output.write(document)
 
 
-def _build_consolidated_model(modules):
+def _build_consolidated_model(ctx, modules):
     main_module = modules[0]
     module_element = _make_builtin_yin_element_recursive(main_module)
 
@@ -91,6 +101,13 @@ def _make_builtin_yin_element_recursive(statement, parent_elem=None):
 
 
 def _make_builtin_yin_element(statement, parent_elem):
+    if statement.keyword in {"uses", "grouping"}:
+        msg = "Stmt {!r}:\n  validated: {}\n  expanded: {}".format(
+            statement,
+            getattr(statement, "i_is_validated", False),
+            getattr(statement, "i_expanded", False))
+        LOG.debug(msg)
+
     try:
         argument_name, is_arg_yin_element = syntax.yin_map[statement.keyword]
     except KeyError:
@@ -173,6 +190,16 @@ def _add_statement_argument(arg_name, arg_value, namespace, is_element,
 
 
 def _append_children(statement, yin_element):
+    if _is_member_of_grouping(statement) and "ref" in statement.arg:
+        uses = statement.i_uses[0]
+        LOG.debug("Member %r of grouping %r: %r",
+                  statement.arg, uses.arg, statement)
+        LOG.debug("Children: %r", getattr(uses, "i_children", []))
+        LOG.debug("substmts: %r", [(sub.keyword, sub.arg, sub)
+                                   for sub in statement.substmts])
+        LOG.debug("i_learef_ptr: %r", getattr(
+            statement, "i_leafref_ptr", None))
+
     for sub_statement in _iterate_non_data_sub_statements(statement):
         _make_yin_element_recursive(sub_statement, yin_element)
 
@@ -211,8 +238,7 @@ def _append_if_feature_elements_from_augment(augment_statement, yin_element):
 
 def _is_member_of_grouping(statement):
     return (_common.is_data_definition(statement.keyword) and
-            hasattr(statement, 'i_uses') and
-            statement.i_uses is not None)
+            getattr(statement, 'i_uses', None) is not None)
 
 
 def _append_if_feature_elements_from_uses(uses_statements, yin_element):
@@ -252,28 +278,55 @@ def _append_children_for_type(type_statement, yin_element):
                                     parent_elem=yin_element)
 
     data_node = type_statement.parent
+    if "ref" in data_node.arg:
+        LOG.debug("type stmt: %r", type_statement)
+        LOG.debug("data_node %r: %r", data_node.arg, data_node)
+        LOG.debug("i_uses: %r", getattr(data_node, "i_uses", None))
+        LOG.debug("__dict__: %r", getattr(data_node, "__dict__", {}))
+
+        with log_print():
+            data_node.pprint()
+
     if _has_leafref_pointer(data_node):
         referenced_leaf, _ = data_node.i_leafref_ptr
+
+        LOG.debug("Data node with leafref:")
+        LOG.debug("============================")
+
+        with log_print():
+            data_node.pprint()
+
+        LOG.debug("Referenced leaf:")
+        LOG.debug("============================")
+        with log_print():
+            referenced_leaf.pprint()
+
         referenced_type_statement = referenced_leaf.search_one('type')
         _make_yin_element_recursive(referenced_type_statement,
                                     parent_elem=yin_element)
 
+    elif "ref" in data_node.arg:
+        LOG.debug("Data node without leafref:")
+        LOG.debug("i_uses: %r", getattr(data_node, "i_uses", None))
+        LOG.debug("============================")
+        with log_print():
+            data_node.pprint()
+
 
 def _is_typedef(type_statement):
-    return (hasattr(type_statement, 'i_typedef') and
-            type_statement.i_typedef is not None)
+    return getattr(type_statement, 'i_typedef', None) is not None
 
 
 def _has_leafref_pointer(data_node):
-    return (hasattr(data_node, 'i_leafref_ptr') and
-            data_node.i_leafref_ptr is not None)
+    return getattr(data_node, 'i_leafref_ptr', None) is not None
 
 
 def _make_yin_element_recursive(statement, parent_elem):
     if hasattr(statement, 'i_extension'):
         _make_extension_element(statement, parent_elem)
     else:
-        _make_builtin_yin_element_recursive(statement, parent_elem=parent_elem)
+        _make_builtin_yin_element_recursive(
+            statement, parent_elem=parent_elem)
 
 
 def _make_extension_element(statement, parent_elem):

--- a/yinsolidated/plugin/plugin.py
+++ b/yinsolidated/plugin/plugin.py
@@ -174,6 +174,11 @@ def _add_statement_argument(arg_name, arg_value, namespace, is_element,
 
 def _append_children(statement, yin_element):
     for sub_statement in _iterate_non_data_sub_statements(statement):
+        if sub_statement.keyword in {"if-feature", "when"}:
+            if _is_augmenting(statement) or _is_member_of_grouping(statement):
+                # These are handled by the _append_inherited functions
+                continue
+
         _make_yin_element_recursive(sub_statement, yin_element)
 
     _append_inherited_if_feature_elements(statement, yin_element)


### PR DESCRIPTION
Run `yinsolidated` against more recent `pyang` versions, and add test cases for using a leafref in a grouping. (disabled for now with link to upstream defect).

Also move consolidated model fixture out into `conftest` so it can be a `session` scoped fixture, and use `runpy` for better logging + captured output from within the plugin or pyang itself.

f4e1b1a  contains a bunch of changes I made for debugging + logging, so I reverted them but kept in commit history for posterity.