### PR TITLE
JSON YINsolidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # YINsolidated [![Build Status](https://travis-ci.org/128technology/yinsolidated.svg?branch=master)](https://travis-ci.org/128technology/yinsolidated)
 
 ## Overview
+
 **YINsolidated** is a YIN-like representation of a YANG model, consolidated into a single XML file.
 
 While YIN is easier to programmatically consume than YANG, simply because it's XML, it's still just a one-for-one mapping from YANG, which leaves a significant amount of parsing logic up to the consumer. An application that consumes YIN files needs to resolve `uses` statements, `augment` statements, `typedef`s, `identityref`s, `leafref`s, and more.
@@ -8,28 +9,47 @@ While YIN is easier to programmatically consume than YANG, simply because it's X
 **YINsolidated** takes care of all of that overhead for you, providing you with a single XML file representing your entire model.
 
 ## What this package provides
+
 * A `pyang` plugin for generating a **YINsolidated** model from a YANG model consisting of one or more YANG modules
 * A Python library for parsing the **YINsolidated** model into an in-memory XML document with convenient YANG-specific methods and properties layered on top of the elements
 
 ## Installation
+
+```sh
+pip install yinsolidated
 ```
-$ pip install yinsolidated
-```
+
 To generate a **YINsolidated** module, you will need to install `pyang` separately:
-```
-$ pip install pyang
+
+```sh
+pip install pyang
 ```
 
 ## Generating a YINsolidated model
+
 ### With pyang >= 1.7.2
+
 The **YINsolidated** plugin will be automatically recognized by `pyang` by way of `setuptools` entry points, so you simply need to invoke `pyang` with the `yinsolidated` format:
+
+#### Generating the XML Model
+
+```sh
+pyang -f yinsolidated --yinsolidated-output-format=xml -o yinsolidatedModel.xml main-module.yang other-module.yang ...
 ```
-$ pyang -f yinsolidated -o yinsolidatedModel.xml main-module.yang other-module.yang ...
+
+#### Generating the JSON Model
+
+```sh
+pyang -f yinsolidated --yinsolidated-output-format=json -o yinsolidatedModel.json main-module.yang other-module.yang ...
 ```
+
 **NOTE:** The main YANG module (the one that includes other submodules or is augmented by other modules) needs to be passed as the first positional argument.
+
 ### With pyang < 1.7.2
+
 This version of `pyang` does not yet have support for the `setuptools` entry point, so the path in which the plugin is installed must be explicitly passed to the `pyang` command:
-```
+
+```sh
 $ export PLUGINDIR=`/usr/bin/env python -c \
     'import os; from yinsolidated.plugin import plugin; \
     print os.path.dirname(plugin.__file__)'`
@@ -37,21 +57,39 @@ $ pyang --plugindir $PLUGINDIR -f yinsolidated -o yinsolidatedModel.xml main-mod
 ```
 
 ## Parsing a YINsolidated model
+
 ### From a file
+
 ```python
 import yinsolidated
 
 model_tree = yinsolidated.parse('yinsolidatedModel.xml')
 ```
+
 ### From a string
+
 ```python
 import yinsolidated
 
 with open('yinsolidatedModel.xml') as model_file:
     model_string = model_file.read()
 
-model_tree = yinsolidated.fromstring(model_string)
+model_tree_from_xml = yinsolidated.fromstring(model_string)
+```
+
+### From JSON
+
+```python
+import yinsolidated
+
+model_tree = yinsolidated.parse_json(
+    # generated using --yinsolidated-output-format=json
+    'yinsolidatedModel.json'
+)
 ```
 
 ## Documentation
-[The YINsolidated Format](docs/Format.md)
+
+[The YINsolidated XML Format](docs/XMLFormat.md) (generated using `--yinsolidated-output-format=xml`)
+
+[The YINsolidated JSON Format](docs/JSONFormat.md) (generated using `--yinsolidated-output-format=json`)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ pyang --plugindir $PLUGINDIR -f yinsolidated -o yinsolidatedModel.xml main-mod
 
 ## Parsing a YINsolidated model
 
-### From a file
+### From a XML file
 
 ```python
 import yinsolidated
@@ -66,7 +66,7 @@ import yinsolidated
 model_tree = yinsolidated.parse('yinsolidatedModel.xml')
 ```
 
-### From a string
+### From a XML string
 
 ```python
 import yinsolidated
@@ -74,18 +74,19 @@ import yinsolidated
 with open('yinsolidatedModel.xml') as model_file:
     model_string = model_file.read()
 
-model_tree_from_xml = yinsolidated.fromstring(model_string)
+model_tree = yinsolidated.fromstring(model_string)
 ```
 
-### From JSON
+### From a JSON file
 
 ```python
 import yinsolidated
 
-model_tree = yinsolidated.parse_json(
-    # generated using --yinsolidated-output-format=json
-    'yinsolidatedModel.json'
-)
+# generated using --yinsolidated-output-format=json
+with open('yinsolidatedModel.json') as model_file:
+    contents = model_file.read()
+
+model_tree = yinsolidated.parse_json(contents)
 ```
 
 ## Documentation

--- a/docs/JSONFormat.md
+++ b/docs/JSONFormat.md
@@ -1,0 +1,551 @@
+# YINsolidated Format
+
+The goal of YINsolidated is to generate a single JSON document with all augments and
+submodules merged together. Because the native `yin` format is XML there are some
+oddities when converting to JSON.
+
+What would be a XML node becomes a JSON Object that represents a single `YinElement`
+with the following schema:
+
+- Each object always has a `"keyword": string`. This would be the XML element tag.
+- Sub-objects are grouped under `"children": YinElement[]`.
+- Each object has `namespace: string`
+- Each object has `nsmap: { [prefix: string]: string }` which is a mapping of namespace-prefix to uri
+- All other attributes are optional.
+
+Additionally the following transformations are applied:
+
+## Submodules
+
+All data definitions within a `submodule` are included as child elements of the
+main module element.
+
+## Augments
+
+* All `augment` statements are resolved such that all data definition statements
+  within the `augment` are added as child elements to the element indicated by
+  the `augment`'s target node.
+
+* Any `when` sub-statements of an `augment` are added as child elements to each
+  of the augmenting data definition elements described above. To differentiate
+  these from actual `when` sub-statements of those data definitions, the added
+  `when` elements are given a `context-node="parent"` attribute. This way, the
+  `when` statement still makes the data definition conditional, and the XPath
+  expression can be evaluated against the proper context node.
+
+* Similarly, any `if-feature` sub-statements of an `augment` are added as child
+  elements to each of the augmenting data definitions. No modifications to
+  these elements are necessary because they still make the data definition
+  dependent on the feature.
+
+E.g. this YANG snippet:
+
+```yang
+container augmented-container;
+
+augment "augmented-container" {
+    if-feature my-feature;
+    when "a-leaf != 'foo'";
+
+    container augmenting-container;
+
+    leaf augmenting-leaf {
+        type string;
+    }
+}
+```
+
+Becomes:
+
+```json
+{
+  "keyword": "container",
+  "name": "augmented-container",
+  "children": [
+    {
+      "keyword": "container",
+      "name": "augmenting-container",
+      "children": [
+        { "keyword": "if-feature", "name": "my-feature" },
+        { "keyword": "when", "condition": "a-leaf != 'foo'", "context-node": "parent" }
+      ]
+    },
+    {
+      "keyword": "leaf",
+      "name": "augmenting-leaf",
+      "children": [
+        { "keyword": "if-feature", "name": "my-feature"},
+        { "keyword": "when", "condition": "a-leaf != 'foo'", "context-node": "parent" }
+        { "keyword": "type", "name": "string" }
+      ]
+    }
+  ]
+}
+```
+
+## Uses
+
+* All `uses` statements are resolved such that all data definitions sub-
+  statements of the used `grouping` (grouped data definitions) are added as
+  elements in place of the `uses` statement.
+
+* All `when` sub-statements of a `uses` are handled exactly the same way as
+  those of an `augment`, except they are added to the grouped data definition
+  elements.
+
+* All `if-feature` sub-statements of a `uses` are handled in the same way as
+  those of an `augment`, except they are added to the grouped data
+  definition elements.
+
+E.g. this YANG snippet:
+
+```yang
+grouping my-grouping {
+    if-feature my-feature;
+    when "a-leaf != 'foo'";
+
+    container grouped-container;
+
+    leaf grouped-leaf {
+        type string;
+    }
+}
+
+container root {
+    uses my-grouping;
+}
+```
+
+Becomes:
+
+```json
+{
+  "keyword": "root",
+  "name": "grouped-container",
+  "children": [
+    {
+      "keyword": "container",
+      "name": "grouped-container",
+      "children": [
+        { "keyword": "if-feature", "name": "my-feature" },
+        { "keyword": "when", "condition": "a-leaf != 'foo'", "context-node": "parent" }
+      ]
+    },
+    {
+      "keyword": "leaf",
+      "name": "grouped-leaf",
+      "children": [
+        { "keyword": "if-feature", "name": "my-feature"},
+        { "keyword": "when", "condition": "a-leaf != 'foo'", "context-node": "parent" }
+        { "keyword": "type", "name": "string" }
+      ]
+    }
+  ]
+}
+```
+
+## Typedefs
+
+Any `type` statement that refers to a `typedef` is resolved recursively, such
+that the `typedef` is added as a child element of the `type` element. The
+`typedef` itself has a child `type` element, which will also be resolved if it
+refers to another `typedef`.
+
+E.g. this YANG snippet:
+
+```yang
+typedef base-type {
+    type string {
+        length 1..255;
+    }
+}
+
+typedef derived-type {
+    type base-type {
+        length 10;
+    }
+}
+
+leaf my-leaf {
+    type derived-type {
+        pattern "[A-Z]*";
+    }
+}
+```
+
+Becomes:
+
+```json
+{
+  "keyword": "leaf",
+  "name": "my-leaf",
+  "children": [
+    {
+      "keyword": "type",
+      "name": "derived-type",
+      "children": [
+        { "keyword": "pattern", "value": "[A-Z]*" },
+        {
+          "keyword": "typedef",
+          "name": "derived-type",
+          "children": [
+            {
+              "keyword": "type",
+              "name": "base-type",
+              "children": [
+                { "keyword": "length", "value": "10" },
+                {
+                  "keyword": "typedef",
+                  "name": "base-type",
+                  "children": [
+                    {
+                      "keyword": "type",
+                      "name": "string",
+                      "children": [{ "keyword": "length", "value": "1..255" }]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Leafrefs
+
+Any `leafref` type is resolved such that the `type` statement of the referenced
+`leaf` is added as a child element to the `type` element. If the type of the
+referenced `leaf` is a `typedef`, it will be resolved as described in the
+[Typedefs](#typedefs) section.
+
+E.g. this YANG snippet:
+
+```yang
+leaf referenced-leaf {
+    type string;
+}
+
+leaf referring-leaf {
+    type leafref {
+        path "/referenced-leaf";
+    }
+}
+```
+
+Becomes:
+
+```json
+{
+  "keyword": "leaf",
+  "name": "referenced-string",
+},
+{
+  "keyword": "leaf",
+  "name": "referring-leaf",
+  "children": [
+    {
+      "keyword": "type",
+      "name": "leafref",
+      "children": [
+        { "keyword": "path", "value": "/referenced-leaf" },
+        { "keyword": "type", "name": "string" },
+      ]
+    }
+  ]
+}
+```
+
+## Extensions
+
+`extension` statements can be represented in the **YINsolidated** model in two different ways.
+
+### Simple Extensions
+
+This is the default format, which provides a simplified representation over the traditional YIN format. Each `extension` statement is simply added as a child element of its parent statement, and its argument is set as the text of that element.
+
+E.g. this YANG snippet:
+
+```yang
+namespace "foo:ns";
+prefix foo;
+
+extension element-ext {
+    argument element-arg {
+        yin-element true;
+    }
+}
+
+extension attribute-ext {
+    argument attribute-arg {
+        yin-element false;
+    }
+}
+
+foo:element-ext "Element text";
+foo:attribute-ext "Attribute text" {
+    description "This won't appear in YINsolidated";
+}
+```
+
+Becomes:
+
+```json
+{
+    "keyword": "element-ext",
+    "namespace": "foo:ns",
+    "nsmap": { "foo": "foo:ns" },
+    "text": "Element text"
+},
+{
+    "keyword": "attribute-ext",
+    "namespace": "foo:ns",
+    "nsmap": { "foo": "foo:ns" },
+    "text": "Attribute text"
+}
+```
+
+### Complex (YIN-formatted) Extensions
+
+The simple format does not support sub-statements on extensions. To support this use case, the traditional YIN format can be enabled by adding the tag `#yinformat` to the extension description.
+
+In this format, each `extension` statement is added as a child element of its parent statement, and its argument can be set either as an attribute on that element or as a child element.
+
+E.g. this YANG snippet:
+
+```yang
+namespace "foo:ns";
+prefix foo;
+
+extension element-ext {
+    argument element-arg {
+        yin-element true;
+    }
+    description "This should follow #yinformat";
+}
+
+extension attribute-ext {
+    argument attribute-arg {
+        yin-element false;
+    }
+    description "This should follow #yinformat";
+}
+
+foo:element-ext "Element text";
+foo:attribute-ext "Attribute text" {
+    description "This will appear in YINsolidated";
+}
+```
+
+Becomes:
+
+```json
+{
+    "keyword": "element-ext",
+    "namespace": "foo:ns",
+    "nsmap": { "foo": "foo:ns" },
+    "text": "Element text"
+},
+{
+    "keyword": "attribute-ext",
+    "namespace": "foo:ns",
+    "nsmap": { "foo": "foo:ns" },
+    "attribute-arg": "Attribute text",
+    "children": [{ "keyword": "description", "text": "This will appear in YINsolidated" }]
+}
+```
+
+## Cases
+
+The `case` statement can be omitted in YANG if the `case` only consists of a
+single data definition statement. When converted to the **YINsolidated** model,
+this data definition element will be wrapped in a `case` element even if the
+`case` statement is omitted.
+
+E.g. this YANG snippet:
+
+```yang
+choice my-choice {
+    case foo {
+        container foo;
+    }
+    container bar;
+}
+```
+
+Becomes:
+
+```json
+{
+  "keyword": "choice",
+  "name": "my-choice",
+  "children": [
+    {
+      "keyword": "case",
+      "name": "foo",
+      "children": [{ "keyword": "container", "name": "foo" }]
+    },
+    {
+      "keyword": "case",
+      "name": "bar",
+      "children": [{ "keyword": "container", "name": "bar" }]
+    }
+  ]
+}
+```
+
+## Omitting Resolved Statements
+
+Any statements that are resolved by the above rules become useless in the
+**YINsolidated** model because the information they convey is represented in-
+place. Thus, the following statements are **NOT** added as elements in the
+**YINsolidated** model:
+
+* `augment`
+* `belongs-to`
+* `grouping`
+* `import`
+* `include`
+* `refine`
+* `submodule`
+* `uses`
+
+## Namespaces and Prefixes
+
+Each module has its own local mapping of prefixes to namespaces for the modules
+it imports, and text values within the module may use these locally defined
+prefixes. Thus, for any given element in the document, it is also necessary to
+know the current namespace mapping. This is accomplished by adding the
+appropriate namespace mappings to the top-level `module` element as well as to
+any augmenting data definitions from external modules.
+
+In addition, each YANG module has its own namespace and associated prefix which
+scopes the data definitions contained in that module. When parsing the model, it
+is important to know the namespace and prefix to which a data definition
+belongs.
+
+To accomplish this, the prefix for the main module is stored as an attribute of
+the top-level module element, and the prefix of any module augmenting the main
+module is stored as an attribute of each augmenting data definition element.
+This way, any data definition element within the document is scoped to the
+prefix of the closest ancestor element with the `module-prefix` attribute. The
+namespace associated with this prefix can be acquired using the namespace
+mapping.
+
+E.g. these YANG modules:
+
+```yang
+module main {
+    namespace "urn:main";
+    prefix main;
+
+    container root;
+}
+
+module augmenting {
+    namespace "urn:augmenting";
+    prefix aug;
+
+    import main {
+        prefix m;
+    }
+
+    augment "/m:root" {
+        leaf my-leaf {
+            types string;
+        }
+    }
+}
+```
+
+Become:
+
+```json
+{
+  "keyword": "module",
+  "name": "main",
+  "module-prefix": "main",
+  "namespace": "urn:main",
+  "nsmap": { "main": "urn:main", "yin": "urn:ietf:params:xml:ns:yang:yin:1" },
+  "children": [
+    {
+      "keyword": "container",
+      "name": "root",
+      "children": [
+        {
+          "keyword": "leaf",
+          "name": "my-leaf",
+          "module-prefix": "aug",
+          "namespace": "urn:augmenting",
+          "nsmap": { "m": "urn:main", "yin": "urn:ietf:params:xml:ns:yang:yin:1" },
+          "children": [{ "keyword": "type", "name": "string" }]
+        },
+      ]
+    }
+  ]
+}
+```
+
+## Identities
+
+Since the **YINsolidated** model contains only one module element, `identity`
+statements defined in other modules are included as children of the module
+element. In order to properly represent namespaces, each identity element is
+given the namespace map from its original module as well as a `module-prefix`
+attribute to indicate the namespace in which it was defined.
+
+E.g. these YANG modules:
+
+```yang
+module main {
+    namespace "urn:main";
+    prefix main;
+
+    identity base-identity;
+}
+
+module augmenting {
+    namespace "urn:augmenting";
+    prefix aug;
+
+    import main {
+        prefix m;
+    }
+
+    identity derived-identity {
+        base m:base-identity;
+    }
+}
+```
+
+Become:
+
+```json
+{
+  "keyword": "module",
+  "name": "main",
+  "module-prefix": "main",
+  "namespace": "urn:main",
+  "nsmap": { "main": "urn:main", "yin": "urn:ietf:params:xml:ns:yang:yin:1" },
+  "children": [
+    {
+      "keyword": "identity",
+      "name": "base-identity",
+      "module-prefix": "main",
+      "namespace": "urn:main",
+      "nsmap": { "main": "urn:main", "yin": "urn:ietf:params:xml:ns:yang:yin:1" },
+    },
+    {
+      "keyword": "identity",
+      "name": "derived-identity",
+      "module-prefix": "aug",
+      "namespace": "urn:augmenting",
+      "nsmap": { "m": "urn:main", "yin": "urn:ietf:params:xml:ns:yang:yin:1", "aug": "url:augmenting" },
+      "children": [{ "keyword": "base", "name": "m:base-identity" }]
+    }
+  ]
+}
+```

--- a/docs/XMLFormat.md
+++ b/docs/XMLFormat.md
@@ -6,12 +6,10 @@ for each YANG file, and the goal of the the **YINsolidated** model is to
 generate a single XML document. Thus, the following additional transformations
 are performed:
 
-
 ## Submodules
 
 All data definitions within a `submodule` are included as child elements of the
 main module element.
-
 
 ## Augments
 
@@ -64,7 +62,6 @@ Becomes:
 </container>
 ```
 
-
 ## Uses
 
 * All `uses` statements are resolved such that all data definitions sub-
@@ -113,7 +110,6 @@ Becomes:
     </leaf>
 </container>
 ```
-
 
 ## Typedefs
 
@@ -164,7 +160,6 @@ Becomes:
 </leaf>
 ```
 
-
 ## Leafrefs
 
 Any `leafref` type is resolved such that the `type` statement of the referenced
@@ -200,12 +195,12 @@ Becomes:
 </leaf>
 ```
 
-
 ## Extensions
 
 `extension` statements can be represented in the **YINsolidated** model in two different ways.
 
 ### Simple Extensions
+
 This is the default format, which provides a simplified representation over the traditional YIN format. Each `extension` statement is simply added as a child element of its parent statement, and its argument is set as the text of that element.
 
 E.g. this YANG snippet:
@@ -240,6 +235,7 @@ Becomes:
 ```
 
 ### Complex (YIN-formatted) Extensions
+
 The simple format does not support sub-statements on extensions. To support this use case, the traditional YIN format can be enabled by adding the tag `#yinformat` to the extension description.
 
 In this format, each `extension` statement is added as a child element of its parent statement, and its argument can be set either as an attribute on that element or as a child element.
@@ -281,7 +277,6 @@ Becomes:
 <foo:attribute-ext>
 ```
 
-
 ## RPC Input and Output
 
 Both an `input` child element and an `output` child element are added to each
@@ -302,7 +297,6 @@ Becomes:
     <output/>
 </rpc>
 ```
-
 
 ## Cases
 
@@ -335,13 +329,13 @@ Becomes:
 </choice>
 ```
 
-
 ## Omitting Resolved Statements
 
 Any statements that are resolved by the above rules become useless in the
 **YINsolidated** model because the information they convey is represented in-
 place. Thus, the following statements are **NOT** added as elements in the
 **YINsolidated** model:
+
 * `augment`
 * `belongs-to`
 * `grouping`
@@ -350,7 +344,6 @@ place. Thus, the following statements are **NOT** added as elements in the
 * `refine`
 * `submodule`
 * `uses`
-
 
 ## Namespaces and Prefixes
 
@@ -417,7 +410,6 @@ Become:
     </container>
 </module>
 ```
-
 
 ## Identities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+# See https://github.com/timothycrosley/isort/issues/694
+# on how this configuration is valid with black.
+line_length=88
+multi_line_output=3
+lines_after_imports=2
+include_trailing_comma=true
+combine_as_imports=true
+
+default_section="THIRDPARTY"
+
+known_first_party = [
+    "yinsolidated",
+]

--- a/setup.py
+++ b/setup.py
@@ -6,44 +6,39 @@
 from setuptools import setup, find_packages
 
 # Read in the __version__ attribute without importing the package
-with open('yinsolidated/_version.py') as version_file:
+with open("yinsolidated/_version.py") as version_file:
     exec(version_file.read())
 
 setup(
-    name='yinsolidated',
+    name="yinsolidated",
     version=__version__,
     description=(
-        'Generates and parses a YIN-like representation of a YANG model, '
-        'consolidated into a single XML document'
+        "Generates and parses a YIN-like representation of a YANG model, "
+        "consolidated into a single XML document"
     ),
-    url='https://github.com/128technology/yinsolidated',
-    author='Alex Thompson',
-    author_email='alex@128technology.com',
-    license='MIT',
+    url="https://github.com/128technology/yinsolidated",
+    author="Alex Thompson",
+    author_email="alex@128technology.com",
+    license="MIT",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    keywords='yang yin pyang',
+    keywords="yang yin pyang",
     packages=find_packages(),
-    install_requires=[
-        'lxml >= 3.7.3',
-        'xpathparser >= 1.0.0'
-    ],
-    python_requires='>=2.7',
+    install_requires=["lxml >= 3.7.3", "xpathparser >= 1.0.0"],
+    python_requires=">=2.7",
     entry_points={
-        'pyang.plugin': [
-            'yinsolidate = yinsolidated.plugin.plugin:pyang_plugin_init'
-        ]
-    }
+        "pyang.plugin": ["yinsolidate = yinsolidated.plugin.plugin:pyang_plugin_init"]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-###############################################################################
-# Copyright (c) 2016-2017 128 Technology, Inc.
-# All rights reserved.
-###############################################################################
+# Copyright 2016 128 Technology, Inc.
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 # Read in the __version__ attribute without importing the package
 with open("yinsolidated/_version.py") as version_file:

--- a/test/_common_test.py
+++ b/test/_common_test.py
@@ -7,51 +7,38 @@ import pytest
 from yinsolidated import _common
 
 
-@pytest.mark.parametrize('keyword', [
-    'container',
-    'leaf',
-    'leaf-list',
-    'list',
-    'anyxml'
-])
+@pytest.mark.parametrize(
+    "keyword", ["container", "leaf", "leaf-list", "list", "anyxml"]
+)
 def test_is_data_node(keyword):
     assert _common.is_data_node(keyword)
 
 
-@pytest.mark.parametrize('keyword', [
-    'choice',
-    'case',
-    'augment',
-    'uses',
-    'module',
-    'rpc',
-    'identity',
-    'foo'
-])
+@pytest.mark.parametrize(
+    "keyword", ["choice", "case", "augment", "uses", "module", "rpc", "identity", "foo"]
+)
 def test_is_not_data_node(keyword):
     assert not _common.is_data_node(keyword)
 
 
-@pytest.mark.parametrize('keyword', [
-    'container',
-    'leaf',
-    'leaf-list',
-    'list',
-    'anyxml',
-    'choice',
-    'case',
-    'augment',
-    'uses'
-])
+@pytest.mark.parametrize(
+    "keyword",
+    [
+        "container",
+        "leaf",
+        "leaf-list",
+        "list",
+        "anyxml",
+        "choice",
+        "case",
+        "augment",
+        "uses",
+    ],
+)
 def test_is_data_definition(keyword):
     assert _common.is_data_definition(keyword)
 
 
-@pytest.mark.parametrize('keyword', [
-    'module',
-    'rpc',
-    'identity',
-    'foo'
-])
+@pytest.mark.parametrize("keyword", ["module", "rpc", "identity", "foo"])
 def test_is_not_data_definition(keyword):
     assert not _common.is_data_definition(keyword)

--- a/test/expected.json
+++ b/test/expected.json
@@ -1,0 +1,2679 @@
+{
+  "keyword": "module",
+  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+  "nsmap": {
+    "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+    "test": "urn:xml:ns:test"
+  },
+  "name": "test-module",
+  "module-prefix": "test",
+  "module-name": "test-module",
+  "children": [
+    {
+      "keyword": "yang-version",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "value": "1"
+    },
+    {
+      "keyword": "namespace",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "uri": "urn:xml:ns:test"
+    },
+    {
+      "keyword": "prefix",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "value": "test"
+    },
+    {
+      "keyword": "organization",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "text": "None"
+    },
+    {
+      "keyword": "contact",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "text": "Somebody"
+    },
+    {
+      "keyword": "description",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "text": "Test module containing an exhaustive set of possible YANG statements"
+    },
+    {
+      "keyword": "revision",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "date": "2016-04-22",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "Initial revision"
+        }
+      ]
+    },
+    {
+      "keyword": "extension",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "simple-extension-no-arg",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An extension that takes no argument and does not support substatements"
+        }
+      ]
+    },
+    {
+      "keyword": "simple-extension-no-arg",
+      "namespace": "urn:xml:ns:test",
+      "nsmap": {
+        "test": "urn:xml:ns:test"
+      },
+      "text": null
+    },
+    {
+      "keyword": "extension",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "simple-extension-attribute-arg",
+      "children": [
+        {
+          "keyword": "argument",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "attribute-argument"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An extension whose argument would appear as an XML attribute in YIN but appears simply as text in YINsolidated and does not support substatements"
+        }
+      ]
+    },
+    {
+      "keyword": "simple-extension-attribute-arg",
+      "namespace": "urn:xml:ns:test",
+      "nsmap": {
+        "test": "urn:xml:ns:test"
+      },
+      "text": "test-value"
+    },
+    {
+      "keyword": "extension",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "simple-extension-element-arg",
+      "children": [
+        {
+          "keyword": "argument",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "element-argument",
+          "children": [
+            {
+              "keyword": "yin-element",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An extension whose argument would appear as an XML subelement in YIN but appears simply as text in YINsolidated and does not support substatements"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        }
+      ]
+    },
+    {
+      "keyword": "simple-extension-element-arg",
+      "namespace": "urn:xml:ns:test",
+      "nsmap": {
+        "test": "urn:xml:ns:test"
+      },
+      "text": "test-value"
+    },
+    {
+      "keyword": "extension",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "complex-extension-no-arg",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An extension that takes no argument but supports substatements because the #yinformat tag is included"
+        }
+      ]
+    },
+    {
+      "keyword": "complex-extension-no-arg",
+      "namespace": "urn:xml:ns:test",
+      "nsmap": {
+        "test": "urn:xml:ns:test"
+      },
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "This will appear in YINsolidated"
+        },
+        {
+          "keyword": "simple-extension-no-arg",
+          "namespace": "urn:xml:ns:test",
+          "nsmap": {
+            "test": "urn:xml:ns:test"
+          },
+          "text": null
+        }
+      ]
+    },
+    {
+      "keyword": "extension",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "complex-extension-attribute-arg",
+      "children": [
+        {
+          "keyword": "argument",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "attribute-argument"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An extension whose argument appears as an XML attribute in YINsolidated and supports substatements because the #yinformat tag is included"
+        }
+      ]
+    },
+    {
+      "keyword": "complex-extension-attribute-arg",
+      "namespace": "urn:xml:ns:test",
+      "nsmap": {
+        "test": "urn:xml:ns:test"
+      },
+      "attribute-argument": "another-test-value",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "This will appear in YINsolidated"
+        },
+        {
+          "keyword": "simple-extension-attribute-arg",
+          "namespace": "urn:xml:ns:test",
+          "nsmap": {
+            "test": "urn:xml:ns:test"
+          },
+          "text": "test-value"
+        }
+      ]
+    },
+    {
+      "keyword": "extension",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "complex-extension-element-arg",
+      "children": [
+        {
+          "keyword": "argument",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "element-argument",
+          "children": [
+            {
+              "keyword": "yin-element",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An extension whose argument appears as an XML subelement in YINsolidated and supports substatements because the #yinformat tag is included"
+        }
+      ]
+    },
+    {
+      "keyword": "complex-extension-element-arg",
+      "namespace": "urn:xml:ns:test",
+      "nsmap": {
+        "test": "urn:xml:ns:test"
+      },
+      "element-argument": "another-test-value",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "This will appear in YINsolidated"
+        },
+        {
+          "keyword": "simple-extension-element-arg",
+          "namespace": "urn:xml:ns:test",
+          "nsmap": {
+            "test": "urn:xml:ns:test"
+          },
+          "text": "test-value"
+        }
+      ]
+    },
+    {
+      "keyword": "feature",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "test-feature",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A test feature"
+        }
+      ]
+    },
+    {
+      "keyword": "identity",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+        "test": "urn:xml:ns:test"
+      },
+      "name": "test-base-identity",
+      "module-prefix": "test",
+      "module-name": "test-module",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A base identity"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        }
+      ]
+    },
+    {
+      "keyword": "identity",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+        "test": "urn:xml:ns:test"
+      },
+      "name": "test-derived-identity",
+      "module-prefix": "test",
+      "module-name": "test-module",
+      "children": [
+        {
+          "keyword": "base",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-base-identity"
+        }
+      ]
+    },
+    {
+      "keyword": "container",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "submodule-container"
+    },
+    {
+      "keyword": "anyxml",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "root-anyxml",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "false"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "An anyxml node at the model root"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "mandatory",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "true"
+        },
+        {
+          "keyword": "must",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "deprecated"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        }
+      ]
+    },
+    {
+      "keyword": "choice",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "root-choice",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "true"
+        },
+        {
+          "keyword": "default",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "test-case"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A choice at the model root"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "mandatory",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "false"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "obsolete"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "anyxml-case",
+          "children": [
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "anyxml-case"
+            }
+          ]
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-case",
+          "children": [
+            {
+              "keyword": "description",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "text": "A test case"
+            },
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "test-feature"
+            },
+            {
+              "keyword": "reference",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "text": "RFC 6020"
+            },
+            {
+              "keyword": "status",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "current"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "../root-leaf != 'nonsense'"
+            },
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "anyxml-within-case"
+            },
+            {
+              "keyword": "choice",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "choice-within-case"
+            },
+            {
+              "keyword": "container",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "container-within-case"
+            },
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "leaf-within-case",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            },
+            {
+              "keyword": "leaf-list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "leaf-list-within-case",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            },
+            {
+              "keyword": "list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "list-within-case",
+              "children": [
+                {
+                  "keyword": "config",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "value": "false"
+                }
+              ]
+            },
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "grouped-anyxml"
+            }
+          ]
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "container-case",
+          "children": [
+            {
+              "keyword": "container",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "container-case"
+            }
+          ]
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "leaf-case",
+          "children": [
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "leaf-case",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "leaf-list-case",
+          "children": [
+            {
+              "keyword": "leaf-list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "leaf-list-case",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "list-case",
+          "children": [
+            {
+              "keyword": "list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "list-case",
+              "children": [
+                {
+                  "keyword": "config",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "value": "false"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "case",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-case",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "augmenting-case-leaf",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "container",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "root-container",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "true"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A container at the model root"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "must",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "test-leaf != 'nonsense'",
+          "children": [
+            {
+              "keyword": "error-message",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "test-leaf is nonsense"
+            }
+          ]
+        },
+        {
+          "keyword": "presence",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "This container has presence"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        },
+        {
+          "keyword": "anyxml",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-anyxml"
+        },
+        {
+          "keyword": "choice",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-choice"
+        },
+        {
+          "keyword": "container",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-nested-container"
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-leaf",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "inner-type",
+              "children": [
+                {
+                  "keyword": "typedef",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "inner-type",
+                  "children": [
+                    {
+                      "keyword": "type",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "leaf-list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-leaf-list",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "keyword": "list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-list",
+          "children": [
+            {
+              "keyword": "config",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "grouped-leaf",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "leaf",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "root-leaf",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "true"
+        },
+        {
+          "keyword": "default",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "test-default"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A leaf at the model root"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "mandatory",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "false"
+        },
+        {
+          "keyword": "must",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "count(../root-leaf-list) > 0"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        },
+        {
+          "keyword": "type",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "string"
+        },
+        {
+          "keyword": "units",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "goobers"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "count(../root-leaf-list) > 0"
+        }
+      ]
+    },
+    {
+      "keyword": "leaf-list",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "root-leaf-list",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "true"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A leaf-list at the model root"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "max-elements",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "10"
+        },
+        {
+          "keyword": "min-elements",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "1"
+        },
+        {
+          "keyword": "must",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        },
+        {
+          "keyword": "ordered-by",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "user"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        },
+        {
+          "keyword": "type",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "string"
+        },
+        {
+          "keyword": "units",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "awesomeness"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        }
+      ]
+    },
+    {
+      "keyword": "list",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "root-list",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "true"
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A list at the model root"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "key",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "test-key"
+        },
+        {
+          "keyword": "max-elements",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "100"
+        },
+        {
+          "keyword": "min-elements",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "50"
+        },
+        {
+          "keyword": "must",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        },
+        {
+          "keyword": "ordered-by",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "system"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        },
+        {
+          "keyword": "unique",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "tag": "grouped-leaf"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'"
+        },
+        {
+          "keyword": "anyxml",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-anyxml"
+        },
+        {
+          "keyword": "choice",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-choice"
+        },
+        {
+          "keyword": "container",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-container"
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-key",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "inner-type",
+              "children": [
+                {
+                  "keyword": "typedef",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "inner-type",
+                  "children": [
+                    {
+                      "keyword": "type",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "leaf-list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-leaf-list",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "keyword": "list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-nested-list",
+          "children": [
+            {
+              "keyword": "config",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "grouped-leaf",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "choice",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "grouped-choice",
+      "children": [
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'",
+          "context-node": "parent"
+        }
+      ]
+    },
+    {
+      "keyword": "container",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "grouped-container",
+      "children": [
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'",
+          "context-node": "parent"
+        },
+        {
+          "keyword": "anyxml",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "augmented-in-uses-anyxml",
+          "children": [
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "../grouped-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "leaf",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "grouped-leaf",
+      "children": [
+        {
+          "keyword": "type",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "grouped-typedef",
+          "children": [
+            {
+              "keyword": "typedef",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "grouped-typedef",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A leaf in a grouping with a refined description"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'",
+          "context-node": "parent"
+        }
+      ]
+    },
+    {
+      "keyword": "leaf-list",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "grouped-leaf-list",
+      "children": [
+        {
+          "keyword": "type",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "string"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'",
+          "context-node": "parent"
+        }
+      ]
+    },
+    {
+      "keyword": "list",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "grouped-list",
+      "children": [
+        {
+          "keyword": "config",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "false"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'",
+          "context-node": "parent"
+        }
+      ]
+    },
+    {
+      "keyword": "anyxml",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "nested-grouped-anyxml",
+      "children": [
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "../root-leaf != 'nonsense'",
+          "context-node": "parent"
+        },
+        {
+          "keyword": "when",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "condition": "grouped-leaf != 'nonsense'",
+          "context-node": "parent"
+        }
+      ]
+    },
+    {
+      "keyword": "leaf",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "leaf-with-typedef",
+      "children": [
+        {
+          "keyword": "type",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "derived-typedef",
+          "children": [
+            {
+              "keyword": "typedef",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "derived-typedef",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "base-typedef",
+                  "children": [
+                    {
+                      "keyword": "length",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "value": "11 | 42..max"
+                    },
+                    {
+                      "keyword": "typedef",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "base-typedef",
+                      "children": [
+                        {
+                          "keyword": "default",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "value": "bumfuzzling"
+                        },
+                        {
+                          "keyword": "description",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "text": "A base typedef"
+                        },
+                        {
+                          "keyword": "reference",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "text": "RFC 6020"
+                        },
+                        {
+                          "keyword": "status",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "value": "current"
+                        },
+                        {
+                          "keyword": "type",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "name": "string",
+                          "children": [
+                            {
+                              "keyword": "length",
+                              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                              "nsmap": {
+                                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                              },
+                              "value": "1..255"
+                            }
+                          ]
+                        },
+                        {
+                          "keyword": "units",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "name": "nonsense"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "leaf",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "leaf-with-leafref",
+      "children": [
+        {
+          "keyword": "type",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "leafref",
+          "children": [
+            {
+              "keyword": "path",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "../root-leaf"
+            },
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "container",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "augmented-container",
+      "children": [
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "augmenting-leaf-internal",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "keyword": "anyxml",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-anyxml",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        },
+        {
+          "keyword": "choice",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-choice",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        },
+        {
+          "keyword": "container",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-container",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "simple-extension-attribute-arg",
+              "namespace": "urn:xml:ns:test",
+              "nsmap": {
+                "t": "urn:xml:ns:test"
+              },
+              "text": "extension used in external augment"
+            },
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-leaf",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            },
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        },
+        {
+          "keyword": "leaf-list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-leaf-list",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            },
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        },
+        {
+          "keyword": "list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "augmenting-list",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "config",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "value": "false"
+            },
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        },
+        {
+          "keyword": "anyxml",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+            "aug": "urn:xml:ns:test:augment",
+            "t": "urn:xml:ns:test"
+          },
+          "name": "grouped-anyxml",
+          "module-prefix": "aug",
+          "module-name": "augmenting-module",
+          "children": [
+            {
+              "keyword": "if-feature",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "t:test-feature"
+            },
+            {
+              "keyword": "when",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "condition": "/t:root-leaf != 'nonsense'",
+              "context-node": "parent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "notification",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "test-notification",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A test notification"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        },
+        {
+          "keyword": "anyxml",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "notification-anyxml"
+        },
+        {
+          "keyword": "choice",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "notification-choice"
+        },
+        {
+          "keyword": "container",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "notification-container"
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "notification-leaf",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "inner-type",
+              "children": [
+                {
+                  "keyword": "typedef",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "inner-type",
+                  "children": [
+                    {
+                      "keyword": "type",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "string"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "keyword": "leaf-list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "notification-leaf-list",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "keyword": "list",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "notification-list"
+        },
+        {
+          "keyword": "leaf",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "grouped-leaf",
+          "children": [
+            {
+              "keyword": "type",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "rpc",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+      },
+      "name": "test-rpc",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A test RPC"
+        },
+        {
+          "keyword": "if-feature",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "test-feature"
+        },
+        {
+          "keyword": "reference",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "RFC 6020"
+        },
+        {
+          "keyword": "status",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "value": "current"
+        },
+        {
+          "keyword": "input",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "children": [
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "input-anyxml"
+            },
+            {
+              "keyword": "choice",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "input-choice"
+            },
+            {
+              "keyword": "container",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "input-container"
+            },
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "input-leaf",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "input-type",
+                  "children": [
+                    {
+                      "keyword": "typedef",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "input-type",
+                      "children": [
+                        {
+                          "keyword": "type",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "name": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "keyword": "leaf-list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "input-leaf-list",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "inner-type",
+                  "children": [
+                    {
+                      "keyword": "typedef",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "inner-type",
+                      "children": [
+                        {
+                          "keyword": "type",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "name": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "keyword": "list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "input-list"
+            },
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "grouped-leaf",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            },
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "grouped-anyxml"
+            }
+          ]
+        },
+        {
+          "keyword": "output",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "children": [
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "output-anyxml"
+            },
+            {
+              "keyword": "choice",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "output-choice"
+            },
+            {
+              "keyword": "container",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "output-container"
+            },
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "output-leaf",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "output-type",
+                  "children": [
+                    {
+                      "keyword": "typedef",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "output-type",
+                      "children": [
+                        {
+                          "keyword": "type",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "name": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "keyword": "leaf-list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "output-leaf-list",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "inner-type",
+                  "children": [
+                    {
+                      "keyword": "typedef",
+                      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                      "nsmap": {
+                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                      },
+                      "name": "inner-type",
+                      "children": [
+                        {
+                          "keyword": "type",
+                          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                          "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                          },
+                          "name": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "keyword": "list",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "output-list"
+            },
+            {
+              "keyword": "leaf",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "grouped-leaf",
+              "children": [
+                {
+                  "keyword": "type",
+                  "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                  "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+                  },
+                  "name": "string"
+                }
+              ]
+            },
+            {
+              "keyword": "anyxml",
+              "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+              "nsmap": {
+                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+              },
+              "name": "grouped-anyxml"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "keyword": "identity",
+      "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+      "nsmap": {
+        "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+        "aug": "urn:xml:ns:test:augment",
+        "t": "urn:xml:ns:test"
+      },
+      "name": "augmenting-derived-identity",
+      "module-prefix": "aug",
+      "module-name": "augmenting-module",
+      "children": [
+        {
+          "keyword": "description",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "text": "A derived identity in an augmenting module"
+        },
+        {
+          "keyword": "base",
+          "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+          "nsmap": {
+            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
+          },
+          "name": "t:test-base-identity"
+        }
+      ]
+    }
+  ]
+}

--- a/test/json_parser_test.py
+++ b/test/json_parser_test.py
@@ -1,0 +1,1867 @@
+# Copyright 2016 128 Technology, Inc.
+
+"""Unit tests for the yinsolidated module"""
+
+from __future__ import unicode_literals
+
+import pytest
+
+import yinsolidated
+
+
+class TestYinElement(object):
+    def test_keyword(self):
+        module_elem = yinsolidated.parse_json({"keyword": "module"})
+
+        assert module_elem.keyword == "module"
+
+    def test_namespace_from_module(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "t",
+                "children": [
+                    {
+                        "keyword": "choice",
+                        "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+                            "t": "test:ns",
+                        },
+                    }
+                ],
+            }
+        )
+        choice_elem = module_elem.find("choice")
+
+        assert choice_elem.namespace == "test:ns"
+
+    def test_namespace_from_augmenting_node(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "out",
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                "nsmap": {
+                    "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+                    "out": "outer:ns",
+                },
+                "children": [
+                    {
+                        "keyword": "test-container",
+                        "module-prefix": "in",
+                        "nsmap": {
+                            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+                            "in": "inner:ns",
+                        },
+                        "children": [
+                            {
+                                "keyword": "choice",
+                                "namespace": "inner:ns",
+                                "nsmap": {
+                                    "yin": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    "in": "inner:ns",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        choice_elem = module_elem.find("test-container").find("choice")
+
+        assert choice_elem.namespace == "inner:ns"
+
+    def test_module_name_from_module(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-name": "test-module",
+                "children": [{"keyword": "choice"}],
+            }
+        )
+        choice_elem = module_elem.find("choice")
+
+        assert choice_elem.module_name == "test-module"
+
+    def test_module_name_from_augmenting_node(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-name": "test-module",
+                "children": [
+                    {
+                        "keyword": "container",
+                        "module-name": "inner-module",
+                        "children": [{"keyword": "choice"}],
+                    }
+                ],
+            }
+        )
+        choice_elem = module_elem.find("container").find("choice")
+
+        assert choice_elem.module_name == "inner-module"
+
+    def test_missing_module_name(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "children": [{"keyword": "container", "name": "test"}],
+            }
+        )
+        choice_elem = module_elem.find("container")
+
+        with pytest.raises(
+            yinsolidated.MissingModuleNameError,
+            match="No module-name attribute found for ancestors of container 'test'",
+        ):
+            _ = choice_elem.module_name
+
+    def test_prefix_from_module(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "test",
+                "children": [{"keyword": "choice"}],
+            }
+        )
+        choice_elem = module_elem.find("choice")
+
+        assert choice_elem.prefix == "test"
+
+    def test_prefix_from_augmenting_node(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "outer",
+                "children": [
+                    {
+                        "keyword": "container",
+                        "module-prefix": "inner",
+                        "children": [{"keyword": "choice"}],
+                    }
+                ],
+            }
+        )
+        choice_elem = module_elem.find("container").find("choice")
+
+        assert choice_elem.prefix == "inner"
+
+    def test_missing_prefix(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "children": [{"keyword": "container", "name": "test"}],
+            }
+        )
+        choice_elem = module_elem.find("container")
+
+        with pytest.raises(
+            yinsolidated.MissingPrefixError,
+            match="No prefix attribute found for ancestors of container 'test'",
+        ):
+            _ = choice_elem.prefix
+
+    def test_description(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "children": [{"keyword": "description", "text": "short description"}],
+            }
+        )
+
+        assert module_elem.description == "short description"
+
+    def test_description(self):
+        module_elem = yinsolidated.parse_json({"keyword": "module",})
+
+        assert module_elem.description is None
+
+    def test_child_data_definitions(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "children": [
+                    {"keyword": "container"},
+                    {"keyword": "list"},
+                    {"keyword": "choice"},
+                    {"keyword": "case"},
+                    {"keyword": "foobar"},
+                    {"keyword": "leaf-list"},
+                    {"keyword": "leaf"},
+                    {"keyword": "anyxml"},
+                    {"keyword": "rpc"},
+                ],
+            }
+        )
+
+        assert len(list(module_elem.iterate_data_definitions())) == 7
+
+
+@pytest.fixture
+def ancestor_data_node_model():
+    return yinsolidated.parse_json(
+        {
+            "keyword": "module",
+            "module-prefix": "t",
+            "children": [
+                {
+                    "keyword": "container",
+                    "name": "test-container",
+                    "children": [
+                        {
+                            "keyword": "list",
+                            "name": "test-list",
+                            "children": [
+                                {
+                                    "keyword": "choice",
+                                    "name": "test-choice",
+                                    "children": [
+                                        {
+                                            "keyword": "case",
+                                            "name": "case-0",
+                                            "children": [
+                                                {
+                                                    "keyword": "leaf",
+                                                    "children": [
+                                                        {
+                                                            "keyword": "type",
+                                                            "name": "uint8",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "keyword": "case",
+                                            "name": "case-1",
+                                            "children": [
+                                                {
+                                                    "keyword": "leaf-list",
+                                                    "children": [
+                                                        {
+                                                            "keyword": "type",
+                                                            "name": "string",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+class TestGetAncestorDataNodes(object):
+    def test_from_leaf_type(self, ancestor_data_node_model):
+        type_elem = (
+            ancestor_data_node_model.find("container")
+            .find("list")
+            .find("choice")
+            .find("case")
+            .find("leaf")
+            .find("type")
+        )
+
+        data_node_ancestors = type_elem.get_ancestor_data_nodes()
+        assert len(data_node_ancestors) == 3
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf"
+
+
+class TestGetAncestorOrSelfDataNodes(object):
+    def test_from_leaf_type(self, ancestor_data_node_model):
+        type_elem = (
+            ancestor_data_node_model.find("container")
+            .find("list")
+            .find("choice")
+            .find("case")
+            .find("leaf")
+            .find("type")
+        )
+
+        data_node_ancestors = type_elem.get_ancestor_or_self_data_nodes()
+        assert len(data_node_ancestors) == 3
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf"
+
+
+class TestModuleElement(object):
+    def test_name(self):
+        module_elem = yinsolidated.parse_json({"keyword": "module", "name": "test"})
+
+        assert module_elem.name == "test"
+
+
+class TestDefinitionElement(object):
+    def test_name(self):
+        choice_elem = yinsolidated.parse_json({"keyword": "choice", "name": "system"})
+
+        assert choice_elem.name == "system"
+
+    def test_status(self):
+        choice_elem = yinsolidated.parse_json(
+            {
+                "keyword": "choice",
+                "children": [{"keyword": "status", "value": "obsolete"}],
+            }
+        )
+
+        assert choice_elem.status == "obsolete"
+
+    def test_default_status(self):
+        choice_elem = yinsolidated.parse_json({"keyword": "choice"})
+
+        assert choice_elem.status == "current"
+
+
+class TestDataDefinitionElement(object):
+    def test_is_config_false(self):
+        choice_elem = yinsolidated.parse_json(
+            {
+                "keyword": "choice",
+                "children": [{"keyword": "config", "value": "false"}],
+            }
+        )
+
+        assert not choice_elem.is_config
+
+    def test_is_config_no_parent(self):
+        choice_elem = yinsolidated.parse_json({"keyword": "choice"})
+
+        assert choice_elem.is_config
+
+    def test_is_config_parent_false(self):
+        choice_elem = yinsolidated.parse_json(
+            {
+                "keyword": "choice",
+                "children": [
+                    {"keyword": "config", "value": "false"},
+                    {"keyword": "leaf"},
+                ],
+            }
+        )
+        leaf_elem = choice_elem.find("leaf")
+
+        assert not leaf_elem.is_config
+
+    def test_when_elements(self):
+        container_elem = yinsolidated.parse_json(
+            {
+                "keyword": "container",
+                "children": [
+                    {"keyword": "when", "condition": "xxx"},
+                    {"keyword": "when", "condition": "yyy"},
+                ],
+            }
+        )
+
+        assert len(container_elem.when_elements) == 2
+
+
+class TestContainerElement(object):
+    def test_presence(self):
+        container_elem = yinsolidated.parse_json(
+            {
+                "keyword": "container",
+                "children": [
+                    {"keyword": "presence", "value": "My existence is meaningful"},
+                ],
+            }
+        )
+
+        assert container_elem.presence == "My existence is meaningful"
+
+    def test_no_presence(self):
+        container_elem = yinsolidated.parse_json({"keyword": "container",})
+
+        assert container_elem.presence is None
+
+
+class TestLeafElement(object):
+    def test_type(self):
+        leaf_elem = yinsolidated.parse_json(
+            {"keyword": "leaf", "children": [{"keyword": "type", "name": "uint8"}]}
+        )
+
+        assert leaf_elem.type.base_type.name == "uint8"
+
+    def test_default(self):
+        leaf_elem = yinsolidated.parse_json(
+            {"keyword": "leaf", "children": [{"keyword": "default", "value": "600"}]}
+        )
+
+        assert leaf_elem.default == "600"
+
+    def test_no_default(self):
+        leaf_elem = yinsolidated.parse_json({"keyword": "leaf"})
+
+        assert leaf_elem.default is None
+
+    def test_units(self):
+        leaf_elem = yinsolidated.parse_json(
+            {"keyword": "leaf", "children": [{"keyword": "units", "name": "seconds"}]}
+        )
+
+        assert leaf_elem.units == "seconds"
+
+    def test_no_units(self):
+        leaf_elem = yinsolidated.parse_json({"keyword": "leaf"})
+
+        assert leaf_elem.units is None
+
+    def test_is_mandatory(self):
+        leaf_elem = yinsolidated.parse_json(
+            {"keyword": "leaf", "children": [{"keyword": "mandatory", "value": "true"}]}
+        )
+
+        assert leaf_elem.is_mandatory
+
+    def test_not_mandatory(self):
+        leaf_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf",
+                "children": [{"keyword": "mandatory", "value": "false"}],
+            }
+        )
+
+        assert not leaf_elem.is_mandatory
+
+    def test_not_mandatory_implicit(self):
+        leaf_elem = yinsolidated.parse_json({"keyword": "leaf"})
+
+        assert not leaf_elem.is_mandatory
+
+    def test_is_list_key(self):
+        list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "list",
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "children": [
+                    {"keyword": "key", "value": "alpha", "nsmap": {"t": "test:ns"},},
+                    {"keyword": "leaf", "name": "alpha", "nsmap": {"t": "test:ns"},},
+                ],
+            }
+        )
+        leaf_elem = list_elem.find("leaf")
+
+        assert leaf_elem.is_list_key
+
+    def test_list_child_not_key(self):
+        list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "list",
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "children": [
+                    {"keyword": "key", "value": "bravo", "nsmap": {"t": "test:ns"}},
+                    {"keyword": "leaf", "name": "alpha", "nsmap": {"t": "test:ns"}},
+                ],
+            }
+        )
+        leaf_elem = list_elem.find("leaf")
+
+        assert not leaf_elem.is_list_key
+
+    def test_non_list_child_not_key(self):
+        leaf_elem = yinsolidated.parse_json({"keyword": "leaf",})
+
+        assert not leaf_elem.is_list_key
+
+
+class TestLeafListElement(object):
+    def test_type(self):
+        leaf_list_elem = yinsolidated.parse_json(
+            {"keyword": "leaf-list", "children": [{"keyword": "type", "name": "uint8"}]}
+        )
+
+        assert leaf_list_elem.type.base_type.name == "uint8"
+
+    def test_units(self):
+        leaf_list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf-list",
+                "children": [{"keyword": "units", "name": "seconds"}],
+            }
+        )
+
+        assert leaf_list_elem.units == "seconds"
+
+    def test_no_units(self):
+        leaf_list_elem = yinsolidated.parse_json({"keyword": "leaf-list"})
+
+        assert leaf_list_elem.units is None
+
+    def test_min_elements(self):
+        leaf_list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf-list",
+                "children": [{"keyword": "min-elements", "value": "10"}],
+            }
+        )
+
+        assert leaf_list_elem.min_elements == 10
+
+    def test_no_min_elements(self):
+        leaf_list_elem = yinsolidated.parse_json({"keyword": "leaf-list"})
+
+        assert leaf_list_elem.min_elements == 0
+
+    def test_max_elements(self):
+        leaf_list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf-list",
+                "children": [{"keyword": "max-elements", "value": "10"}],
+            }
+        )
+
+        assert leaf_list_elem.max_elements == 10
+
+    def test_no_max_elements(self):
+        leaf_list_elem = yinsolidated.parse_json({"keyword": "leaf-list",})
+
+        assert leaf_list_elem.max_elements is None
+
+    def test_ordered_by_user(self):
+        leaf_list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf-list",
+                "children": [{"keyword": "ordered-by", "value": "user"}],
+            }
+        )
+
+        assert leaf_list_elem.ordered_by == "user"
+
+    def test_no_ordered_by(self):
+        leaf_list_elem = yinsolidated.parse_json({"keyword": "leaf-list",})
+
+        assert leaf_list_elem.ordered_by == "system"
+
+
+class TestListElement(object):
+    def test_keys(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "c",
+                "children": [
+                    {
+                        "keyword": "list",
+                        "nsmap": {"a": "alpha:ns", "b": "bravo:ns", "c": "charlie:ns"},
+                        "children": [
+                            {"keyword": "key", "value": "a:alpha b:bravo charlie"},
+                        ],
+                    },
+                ],
+            }
+        )
+        list_elem = module_elem.find("list")
+
+        assert list_elem.key_ids == [
+            ("alpha", "alpha:ns"),
+            ("bravo", "bravo:ns"),
+            ("charlie", "charlie:ns"),
+        ]
+
+    def test_no_keys(self):
+        list_elem = yinsolidated.parse_json({"keyword": "list"})
+
+        assert list_elem.key_ids == []
+
+    def test_unique(self):
+        list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "list",
+                "children": [{"keyword": "unique", "tag": "alpha bravo charlie"},],
+            }
+        )
+
+        assert list_elem.unique == ["alpha", "bravo", "charlie"]
+
+    def test_min_elements(self):
+        list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "list",
+                "children": [{"keyword": "min-elements", "value": "10"}],
+            }
+        )
+
+        assert list_elem.min_elements == 10
+
+    def test_no_min_elements(self):
+        list_elem = yinsolidated.parse_json({"keyword": "list"})
+
+        assert list_elem.min_elements == 0
+
+    def test_max_elements(self):
+        list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "list",
+                "children": [{"keyword": "max-elements", "value": "10"}],
+            }
+        )
+
+        assert list_elem.max_elements == 10
+
+    def test_no_max_elements(self):
+        list_elem = yinsolidated.parse_json({"keyword": "list"})
+
+        assert list_elem.max_elements is None
+
+    def test_ordered_by_user(self):
+        list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "list",
+                "children": [{"keyword": "ordered-by", "value": "user"}],
+            }
+        )
+
+        assert list_elem.ordered_by == "user"
+
+    def test_no_ordered_by(self):
+        list_elem = yinsolidated.parse_json({"keyword": "list"})
+
+        assert list_elem.ordered_by == "system"
+
+
+class TestAnyxmlElement(object):
+    def test_is_mandatory(self):
+        anyxml_elem = yinsolidated.parse_json(
+            {
+                "keyword": "anyxml",
+                "children": [{"keyword": "mandatory", "value": "true"}],
+            }
+        )
+
+        assert anyxml_elem.is_mandatory
+
+    def test_not_mandatory(self):
+        anyxml_elem = yinsolidated.parse_json(
+            {
+                "keyword": "anyxml",
+                "children": [{"keyword": "mandatory", "value": "false"}],
+            }
+        )
+
+        assert not anyxml_elem.is_mandatory
+
+    def test_not_mandatory_implicit(self):
+        anyxml_elem = yinsolidated.parse_json({"keyword": "anyxml",})
+
+        assert not anyxml_elem.is_mandatory
+
+
+class TestTypeElement(object):
+    @pytest.fixture
+    def type_elem_with_unprefixed_name(self):
+        return yinsolidated.parse_json(
+            {
+                "keyword": "leaf",
+                "module-prefix": "a",
+                "nsmap": {"a": "a:ns"},
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "counter",
+                        "nsmap": {"a": "a:ns"},
+                        "children": [{"keyword": "typedef", "name": "uint32"}],
+                    }
+                ],
+            }
+        ).find("type")
+
+    def test_name(self, type_elem_with_unprefixed_name):
+        assert type_elem_with_unprefixed_name.name == "counter"
+
+    def test_unprefixed_name(self, type_elem_with_unprefixed_name):
+        assert type_elem_with_unprefixed_name.unprefixed_name == "counter"
+
+    def test_prefix(self, type_elem_with_unprefixed_name):
+        assert type_elem_with_unprefixed_name.prefix == "a"
+
+    def test_namespace(self, type_elem_with_unprefixed_name):
+        assert type_elem_with_unprefixed_name.namespace == "a:ns"
+
+    def test_base(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "counter",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "percentage",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "meter",
+                                "children": [
+                                    {
+                                        "keyword": "typedef",
+                                        "name": "meter",
+                                        "children": [
+                                            {"keyword": "type", "name": "uint8"}
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert type_elem.base_type.name == "uint8"
+
+    def test_base_for_leafref(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "test-leafref",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "test-leafref",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "leafref",
+                                "children": [{"keyword": "type", "name": "uint32"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        assert type_elem.base_type.name == "leafref"
+
+    def test_base_for_union(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "test-union",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "test-union",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "union",
+                                "children": [
+                                    {"keyword": "type", "name": "uint32"},
+                                    {"keyword": "type", "name": "string"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        assert type_elem.base_type.name == "union"
+
+    def test_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "counter",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "counter",
+                        "children": [{"keyword": "type", "name": "uint32"}],
+                    }
+                ],
+            }
+        )
+
+        assert type_elem.typedef is not None
+
+    def test_no_typedef(self):
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "uint32"},)
+
+        assert type_elem.typedef is None
+
+    def test_bits(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "bits",
+                "children": [
+                    {"keyword": "bit", "name": "alpha"},
+                    {"keyword": "bit", "name": "bravo"},
+                ],
+            },
+        )
+
+        bit_names = [bit.name for bit in type_elem.bits]
+        assert bit_names == ["alpha", "bravo"]
+
+    def test_bits_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "bits",
+                                "children": [
+                                    {"keyword": "bit", "name": "alpha"},
+                                    {"keyword": "bit", "name": "bravo"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        bit_names = [bit.name for bit in type_elem.bits]
+        assert bit_names == ["alpha", "bravo"]
+
+    def test_enums(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "enumeration",
+                "children": [
+                    {"keyword": "enum", "name": "alpha"},
+                    {"keyword": "enum", "name": "bravo"},
+                ],
+            },
+        )
+
+        enum_names = [enum.name for enum in type_elem.enums]
+        assert enum_names == ["alpha", "bravo"]
+
+    def test_enums_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-typedef",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "enumeration",
+                                "children": [
+                                    {"keyword": "enum", "name": "alpha"},
+                                    {"keyword": "enum", "name": "bravo"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+        enum_names = [enum.name for enum in type_elem.enums]
+        assert enum_names == ["alpha", "bravo"]
+
+    def test_fraction_digits(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "decimal64",
+                "children": [{"keyword": "fraction-digits", "value": "2"}],
+            },
+        )
+
+        assert type_elem.fraction_digits == "2"
+
+    def test_fraction_digits_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "decimal64",
+                                "children": [
+                                    {"keyword": "fraction-digits", "value": "2"}
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert type_elem.fraction_digits == "2"
+
+    def test_no_fraction_digits(self):
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+
+        assert type_elem.fraction_digits is None
+
+    def test_base_identity(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "identityref",
+                "children": [{"keyword": "base", "name": "base-identity"}],
+            },
+        )
+
+        assert type_elem.base_identity == "base-identity"
+
+    def test_base_identity_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "identityref",
+                                "children": [
+                                    {"keyword": "base", "name": "base-identity"}
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert type_elem.base_identity == "base-identity"
+
+    def test_identities_base_in_same_namespace(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "t",
+                "children": [
+                    {
+                        "keyword": "identity",
+                        "name": "base-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "derived-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [{"keyword": "base", "name": "base-identity"}],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "nested-derived-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [{"keyword": "base", "name": "derived-identity"}],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "another-base-identity",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "module-prefix": "o",
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "another-derived-identity",
+                        "module-prefix": "o",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [
+                            {"keyword": "base", "name": "another-derived-identity"}
+                        ],
+                    },
+                    {
+                        "keyword": "leaf",
+                        "name": "test-leaf",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "identityref",
+                                "children": [
+                                    {"keyword": "base", "name": "base-identity"}
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+        type_elem = module_elem.find("leaf").find("type")
+
+        identities = type_elem.get_identities()
+
+        assert len(identities) == 2
+        assert identities[0].name == "derived-identity"
+        assert identities[1].name == "nested-derived-identity"
+
+    def test_identities_base_in_different_namespace(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "t",
+                "children": [
+                    {
+                        "keyword": "identity",
+                        "name": "base-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "derived-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [{"keyword": "base", "name": "base-identity"}],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "nested-derived-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [{"keyword": "base", "name": "derived-identity"}],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "another-base-identity",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "module-prefix": "o",
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "another-derived-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [
+                            {"keyword": "base", "name": "o:another-base-identity"}
+                        ],
+                    },
+                    {
+                        "keyword": "leaf",
+                        "name": "test-leaf",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "identityref",
+                                "children": [
+                                    {
+                                        "keyword": "base",
+                                        "name": "o:another-base-identity",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+
+        type_elem = module_elem.find("leaf").find("type")
+
+        identities = type_elem.get_identities()
+
+        assert len(identities) == 1
+        assert identities[0].name == "another-derived-identity"
+
+        def test_missing_identity(self):
+            module_elem = yinsolidated.parse_json(
+                {
+                    "keyword": "module",
+                    "module-prefix": "t",
+                    "children": [
+                        {
+                            "keyword": "leaf",
+                            "name": "test-leaf",
+                            "children": [
+                                {
+                                    "keyword": "type",
+                                    "name": "identityref",
+                                    "children": [
+                                        {"keyword": "base", "name": "t:base-identity"}
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            )
+            type_elem = module_elem.find("leaf").find("type")
+
+            with pytest.raises(yinsolidated.MissingIdentityError):
+                type_elem.get_identities()
+
+    def test_no_identities(self):
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+
+        assert len(type_elem.get_identities()) == 0
+
+    def test_length(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "string",
+                "children": [{"keyword": "length", "value": "1..253"}],
+            },
+        )
+
+        assert type_elem.length == "1..253"
+
+    def test_length_typedefs(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "string",
+                                "children": [{"keyword": "length", "value": "1..253"}],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert type_elem.length == "1..253"
+
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "indirect-fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "another-fake-type",
+                                "children": [
+                                    {
+                                        "keyword": "typedef",
+                                        "name": "fake-type",
+                                        "children": [
+                                            {
+                                                "keyword": "type",
+                                                "name": "string",
+                                                "children": [
+                                                    {
+                                                        "keyword": "length",
+                                                        "value": "8..110",
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        )
+
+        assert type_elem.length == "8..110"
+
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "string",
+                                "children": [{"keyword": "length", "value": "1..17"}],
+                            },
+                        ],
+                    },
+                    {"keyword": "length", "value": "9..17"},
+                ],
+            },
+        )
+
+        assert type_elem.length == "9..17"
+
+    def test_no_length(self):
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+
+        assert type_elem.length is None
+
+    def test_path(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "leafref",
+                "children": [{"keyword": "path", "value": "/a/fake/path"}],
+            },
+        )
+
+        assert type_elem.path == "/a/fake/path"
+
+    def test_path_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "leafref",
+                                "children": [
+                                    {"keyword": "path", "value": "/a/fake/path"}
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+
+        assert type_elem.path == "/a/fake/path"
+
+    def test_no_path(self):
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+
+        assert type_elem.path is None
+
+    def test_patterns(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "string",
+                "children": [
+                    {
+                        "keyword": "pattern",
+                        "value": "[a-zA-Z0-9_\\-]*",
+                        "children": [
+                            {
+                                "keyword": "error-message",
+                                "value": "Must be alphanumeric",
+                            }
+                        ],
+                    },
+                    {"keyword": "pattern", "value": ".*"},
+                ],
+            },
+        )
+
+        assert len(type_elem.patterns) == 2
+
+        assert type_elem.patterns[0].value == r"[a-zA-Z0-9_\-]*"
+        assert type_elem.patterns[0].error_message == "Must be alphanumeric"
+
+        assert type_elem.patterns[1].value == ".*"
+        assert type_elem.patterns[1].error_message is None
+
+    def test_patterns_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "string",
+                                "children": [
+                                    {
+                                        "keyword": "pattern",
+                                        "value": "[a-zA-Z0-9_\\-]*",
+                                        "children": [
+                                            {
+                                                "keyword": "error-message",
+                                                "value": "Must be alphanumeric",
+                                            }
+                                        ],
+                                    },
+                                    {"keyword": "pattern", "value": ".*"},
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert len(type_elem.patterns) == 2
+
+        assert type_elem.patterns[0].value == r"[a-zA-Z0-9_\-]*"
+        assert type_elem.patterns[0].error_message == "Must be alphanumeric"
+
+        assert type_elem.patterns[1].value == ".*"
+        assert type_elem.patterns[1].error_message is None
+
+    def test_range(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "uint8",
+                "children": [{"keyword": "range", "value": "1..253"}],
+            },
+        )
+
+        assert type_elem.range == "1..253"
+
+    def test_range_typedefs(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "uint8",
+                                "children": [{"keyword": "range", "value": "1..253"}],
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+
+        assert type_elem.range == "1..253"
+
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "wrapper",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "fake-type",
+                                "children": [
+                                    {
+                                        "keyword": "typedef",
+                                        "name": "fake-type",
+                                        "children": [
+                                            {
+                                                "keyword": "type",
+                                                "name": "uint8",
+                                                "children": [
+                                                    {
+                                                        "keyword": "range",
+                                                        "value": "7..9",
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert type_elem.range == "7..9"
+
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "fake-type",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "uint8",
+                                "children": [{"keyword": "range", "value": "1..227"}],
+                            },
+                        ],
+                    },
+                    {"keyword": "range", "value": "4..128"},
+                ],
+            }
+        )
+
+        assert type_elem.range == "4..128"
+
+    def test_no_range(self):
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "uint8"},)
+
+        assert type_elem.range is None
+
+    def test_referenced_type_for_leafref(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "leafref",
+                "children": [{"keyword": "type", "name": "string"}],
+            },
+        )
+
+        assert type_elem.referenced_type.base_type.name == "string"
+
+    def test_referenced_type_for_union(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "union",
+                "children": [
+                    {"keyword": "type", "name": "uint8"},
+                    {"keyword": "type", "name": "string"},
+                ],
+            },
+        )
+
+        assert type_elem.referenced_type is None
+
+    def test_referenced_type_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "faketype",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "leafref",
+                                "children": [{"keyword": "type", "name": "string"}],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert type_elem.referenced_type.base_type.name == "string"
+
+    def test_subtypes_for_union(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "union",
+                "children": [
+                    {"keyword": "type", "name": "uint8"},
+                    {"keyword": "type", "name": "string"},
+                ],
+            },
+        )
+
+        subtype_names = [elem.base_type.name for elem in type_elem.subtypes]
+        assert subtype_names == ["uint8", "string"]
+
+    def test_subtypes_for_leafref(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "leafref",
+                "children": [{"keyword": "type", "name": "uint8"}],
+            },
+        )
+
+        assert len(type_elem.subtypes) == 0
+
+    def test_subtypes_typedef(self):
+        type_elem = yinsolidated.parse_json(
+            {
+                "keyword": "type",
+                "name": "fake-type",
+                "children": [
+                    {
+                        "keyword": "typedef",
+                        "name": "faketype",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "union",
+                                "children": [
+                                    {"keyword": "type", "name": "uint8"},
+                                    {"keyword": "type", "name": "string"},
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        subtype_names = [elem.base_type.name for elem in type_elem.subtypes]
+        assert subtype_names == ["uint8", "string"]
+
+
+class TestTypeElementWithPrefixedName(object):
+    @pytest.fixture
+    def type_elem_with_prefixed_name(self):
+        return yinsolidated.parse_json(
+            {
+                "keyword": "leaf",
+                "name": "test-leaf",
+                "module-prefix": "a",
+                "nsmap": {"a": "a:ns", "b": "b:ns"},
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "b:counter",
+                        "nsmap": {"a": "a:ns", "b": "b:ns"},
+                        "children": [
+                            {
+                                "keyword": "typedef",
+                                "name": "counter",
+                                "children": [{"keyword": "type", "name": "uint32"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ).find("type")
+
+    def test_name(self, type_elem_with_prefixed_name):
+        assert type_elem_with_prefixed_name.name == "b:counter"
+
+    def test_unprefixed_name(self, type_elem_with_prefixed_name):
+        assert type_elem_with_prefixed_name.unprefixed_name == "counter"
+
+    def test_prefix(self, type_elem_with_prefixed_name):
+        assert type_elem_with_prefixed_name.prefix == "b"
+
+    def test_namespace(self, type_elem_with_prefixed_name):
+        assert type_elem_with_prefixed_name.namespace == "b:ns"
+
+
+class TestTypedefElement(object):
+    def test_name(self):
+        typedef_elem = yinsolidated.parse_json(
+            {"keyword": "typedef", "name": "counter"},
+        )
+
+        assert typedef_elem.name == "counter"
+
+    def test_type(self):
+        typedef_elem = yinsolidated.parse_json(
+            {
+                "keyword": "typedef",
+                "name": "counter",
+                "children": [{"keyword": "type", "name": "uint32"}],
+            },
+        )
+
+        assert typedef_elem.type.name == "uint32"
+
+    def test_default(self):
+        typedef_elem = yinsolidated.parse_json(
+            {
+                "keyword": "typedef",
+                "name": "counter",
+                "children": [{"keyword": "default", "value": "600"}],
+            },
+        )
+
+        assert typedef_elem.default == "600"
+
+    def test_no_default(self):
+        typedef_elem = yinsolidated.parse_json(
+            {"keyword": "typedef", "name": "counter"},
+        )
+
+        assert typedef_elem.default is None
+
+    def test_units(self):
+        typedef_elem = yinsolidated.parse_json(
+            {
+                "keyword": "typedef",
+                "name": "counter",
+                "children": [{"keyword": "units", "name": "seconds"}],
+            },
+        )
+
+        assert typedef_elem.units == "seconds"
+
+    def test_no_units(self):
+        typedef_elem = yinsolidated.parse_json(
+            {"keyword": "typedef", "name": "counter"},
+        )
+
+        assert typedef_elem.units is None
+
+
+class TestBitElement(object):
+    def test_name(self):
+        bit_elem = yinsolidated.parse_json({"keyword": "bit", "name": "alpha"},)
+
+        assert bit_elem.name == "alpha"
+
+    def test_position(self):
+        bit_elem = yinsolidated.parse_json(
+            {
+                "keyword": "bit",
+                "name": "alpha",
+                "children": [{"keyword": "position", "value": "1"}],
+            },
+        )
+
+        assert bit_elem.position == 1
+
+    def test_no_position(self):
+        bit_elem = yinsolidated.parse_json({"keyword": "bit", "name": "alpha"},)
+
+        assert bit_elem.position is None
+
+
+class TestEnumElement(object):
+    def test_name(self):
+        enum_elem = yinsolidated.parse_json({"keyword": "enum", "name": "alpha"},)
+
+        assert enum_elem.name == "alpha"
+
+    def test_value(self):
+        enum_elem = yinsolidated.parse_json(
+            {
+                "keyword": "enum",
+                "name": "alpha",
+                "children": [{"keyword": "value", "value": "1"}],
+            },
+        )
+
+        assert enum_elem.value == 1
+
+    def test_no_value(self):
+        enum_elem = yinsolidated.parse_json({"keyword": "enum", "name": "alpha"},)
+
+        assert enum_elem.value is None
+
+
+class TestWhenElement(object):
+    def test_no_prefix_added(self):
+        container_elem = yinsolidated.parse_json(
+            {
+                "keyword": "container",
+                "module-prefix": "t",
+                "children": [
+                    {
+                        "keyword": "when",
+                        "condition": "t:foo = 'bar'",
+                        "nsmap": {"t": "test:ns"},
+                    }
+                ],
+            },
+        )
+        when_element = container_elem.find("when")
+
+        assert when_element.condition == "t:foo = 'bar'"
+        assert when_element.namespace_map == {"t": "test:ns"}
+
+    def test_prefix_added(self):
+        container_elem = yinsolidated.parse_json(
+            {
+                "keyword": "container",
+                "module-prefix": "d",
+                "children": [
+                    {
+                        "keyword": "when",
+                        "condition": "../foo/bar = 'alpha' | /t:root/test = 'bravo'",
+                        "nsmap": {"t": "test:ns", "d": "default:ns"},
+                    }
+                ],
+            },
+        )
+
+        when_element = container_elem.find("when")
+
+        assert when_element.condition == (
+            "../d:foo/d:bar = 'alpha' | /t:root/d:test = 'bravo'"
+        )
+
+        assert when_element.namespace_map == {"d": "default:ns", "t": "test:ns"}
+
+    def test_self_context(self):
+        when_element = yinsolidated.parse_json({"keyword": "when"},)
+
+        assert not when_element.context_node_is_parent
+
+    def test_parent_context(self):
+        when_element = yinsolidated.parse_json(
+            {"keyword": "when", "context-node": "parent"},
+        )
+
+        assert when_element.context_node_is_parent
+
+
+class TestIdentityElement(object):
+    def test_name(self):
+        identity_elem = yinsolidated.parse_json(
+            {"keyword": "identity", "name": "test-identity"},
+        )
+
+        assert identity_elem.name == "test-identity"
+
+    def test_namespace(self):
+        identity_elem = yinsolidated.parse_json(
+            {
+                "keyword": "identity",
+                "module-prefix": "t",
+                "name": "test-identity",
+                "nsmap": {"t": "test:ns"},
+            }
+        )
+
+        assert identity_elem.namespace == "test:ns"
+
+    def test_prefix(self):
+        identity_elem = yinsolidated.parse_json(
+            {
+                "keyword": "identity",
+                "module-prefix": "t",
+                "name": "test-identity",
+                "nsmap": {"t": "test:ns"},
+            }
+        )
+
+        assert identity_elem.prefix == "t"
+
+    def test_no_base(self):
+        identity_elem = yinsolidated.parse_json(
+            {"keyword": "identity", "name": "test-identity"},
+        )
+
+        assert identity_elem.base == (None, None)
+
+    def test_base_in_same_namespace(self):
+        identity_elem = yinsolidated.parse_json(
+            {
+                "keyword": "identity",
+                "name": "test-identity",
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "children": [{"keyword": "base", "name": "base-identity"}],
+            }
+        )
+
+        assert identity_elem.base == ("base-identity", "test:ns")
+
+        def test_base_in_different_namespace(self):
+            identity_elem = yinsolidated.parse_json(
+                {
+                    "keyword": "identity",
+                    "name": "test-identity",
+                    "module-prefix": "t",
+                    "nsmap": {"t": "test:ns", "o": "other:ns"},
+                    "children": [{"keyword": "base", "name": "o:base-identity"}],
+                },
+            )
+
+            assert identity_elem.base == ("base-identity", "other:ns")
+
+    def test_iterate_derived_identities(self):
+        module_element = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "children": [
+                    {
+                        "keyword": "identity",
+                        "name": "base-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns"},
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "derived-identity-1",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns"},
+                        "children": [{"keyword": "base", "name": "base-identity"}],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "another-base-identity",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns"},
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "derived-identity-2",
+                        "module-prefix": "t",
+                        "nsmap": {"t": "test:ns"},
+                        "children": [
+                            {"keyword": "base", "name": "another-base-identity"}
+                        ],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "external-derived-identity",
+                        "module-prefix": "o",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [{"keyword": "base", "name": "t:base-identity"}],
+                    },
+                    {
+                        "keyword": "identity",
+                        "name": "nested-derived-identity",
+                        "module-prefix": "o",
+                        "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "children": [
+                            {"keyword": "base", "name": "o:external-derived-identity"}
+                        ],
+                    },
+                ],
+            },
+        )
+        base_identity = module_element.find("identity")
+        assert base_identity.name == "base-identity"
+
+        derived_identities = base_identity.get_derived_identities()
+        print([x.name for x in derived_identities])
+
+        assert len(derived_identities) == 3
+        assert derived_identities[0].name == "derived-identity-1"
+        assert derived_identities[1].name == "external-derived-identity"
+        assert derived_identities[2].name == "nested-derived-identity"
+
+        direct_identities = base_identity.get_directly_derived_identities()
+
+        assert len(direct_identities) == 2
+        assert direct_identities[0].name == "derived-identity-1"
+        assert direct_identities[1].name == "external-derived-identity"

--- a/test/modules/test-module.yang
+++ b/test/modules/test-module.yang
@@ -18,10 +18,10 @@ module test-module {
             "Initial revision";
     }
 
-    // TODO(athompson): bug in pyang? this should be allowed
+    // TODO: bug in pyang? this should be allowed
     // reference "RFC 6020";
 
-    // TODO(athompson): add deviation statement
+    // TODO: add deviation statement
 
 
     /* Extensions */

--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -1707,7 +1707,7 @@ class TestWhenElement(object):
                 <when condition="../foo/bar = 'alpha' | /t:root/test = 'bravo'"/>
             </container>
             """
-        )  # nopep8
+        )
 
         when_element = container_elem.find("yin:when", namespaces=_NSMAP)
 

--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -11,46 +11,48 @@ import pytest
 import yinsolidated
 
 
-_NSMAP = {'yin': 'urn:ietf:params:xml:ns:yang:yin:1'}
+_NSMAP = {"yin": "urn:ietf:params:xml:ns:yang:yin:1"}
 
-_TEST_CONSOLIDATED_MODEL_PATH = os.path.join(
-    os.path.dirname(__file__),
-    'model.xml'
-)
+_TEST_CONSOLIDATED_MODEL_PATH = os.path.join(os.path.dirname(__file__), "model.xml")
 
 
 def test_parse_file():
     model_tree = yinsolidated.parse(_TEST_CONSOLIDATED_MODEL_PATH)
     module_element = model_tree.getroot()
     container_element = module_element.find(
-        'yin:container[@name="test"]', namespaces=_NSMAP)
+        'yin:container[@name="test"]', namespaces=_NSMAP
+    )
 
-    assert container_element.name == 'test'
+    assert container_element.name == "test"
 
 
 class TestYinElement(object):
-
     def test_keyword(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
-        assert module_elem.keyword == 'module'
+        assert module_elem.keyword == "module"
 
     def test_namespace_from_module(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:test="test:ns"
                     module-prefix="test">
                 <choice/>
             </module>
-            """)
-        choice_elem = module_elem.find('yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find("yin:choice", namespaces=_NSMAP)
 
-        assert choice_elem.namespace == 'test:ns'
+        assert choice_elem.namespace == "test:ns"
 
     def test_namespace_from_augmenting_node(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:out="outer:ns"
                     module-prefix="out">
@@ -60,24 +62,28 @@ class TestYinElement(object):
                     <choice/>
                 </container>
             </module>
-            """)
-        choice_elem = module_elem.find('.//yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find(".//yin:choice", namespaces=_NSMAP)
 
-        assert choice_elem.namespace == 'inner:ns'
+        assert choice_elem.namespace == "inner:ns"
 
     def test_module_name_from_module(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     module-name="test-module">
                 <choice/>
             </module>
-            """)
-        choice_elem = module_elem.find('yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find("yin:choice", namespaces=_NSMAP)
 
-        assert choice_elem.module_name == 'test-module'
+        assert choice_elem.module_name == "test-module"
 
     def test_module_name_from_augmenting_node(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     module-name="outer-module">
                 <container name="test-container"
@@ -85,40 +91,46 @@ class TestYinElement(object):
                     <choice/>
                 </container>
             </module>
-            """)
-        choice_elem = module_elem.find('.//yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find(".//yin:choice", namespaces=_NSMAP)
 
-        assert choice_elem.module_name == 'inner-module'
+        assert choice_elem.module_name == "inner-module"
 
     def test_missing_module_name(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <choice/>
             </module>
-            """)
-        choice_elem = module_elem.find('yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find("yin:choice", namespaces=_NSMAP)
 
         with pytest.raises(yinsolidated.MissingModuleNameError) as excinfo:
             # pylint: disable=pointless-statement
             choice_elem.module_name
             assert (
-                str(excinfo.value) ==
-                "No module-name found for ancestors of choice 'None'"
+                str(excinfo.value)
+                == "No module-name found for ancestors of choice 'None'"
             )
 
     def test_prefix_from_module(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     module-prefix="test">
                 <choice/>
             </module>
-            """)
-        choice_elem = module_elem.find('yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find("yin:choice", namespaces=_NSMAP)
 
-        assert choice_elem.prefix == 'test'
+        assert choice_elem.prefix == "test"
 
     def test_prefix_from_augmenting_node(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     module-prefix="outer">
                 <container name="test-container"
@@ -126,38 +138,43 @@ class TestYinElement(object):
                     <choice/>
                 </container>
             </module>
-            """)
-        choice_elem = module_elem.find('.//yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find(".//yin:choice", namespaces=_NSMAP)
 
-        assert choice_elem.prefix == 'inner'
+        assert choice_elem.prefix == "inner"
 
     def test_missing_prefix(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <choice/>
             </module>
-            """)
-        choice_elem = module_elem.find('yin:choice', namespaces=_NSMAP)
+            """
+        )
+        choice_elem = module_elem.find("yin:choice", namespaces=_NSMAP)
 
         with pytest.raises(yinsolidated.MissingPrefixError) as excinfo:
             # pylint: disable=pointless-statement
             choice_elem.prefix
             assert (
-                str(excinfo.value) ==
-                "No prefix found for ancestors of choice 'None'"
+                str(excinfo.value) == "No prefix found for ancestors of choice 'None'"
             )
 
     def test_namespace_map(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:a="alpha"
                     xmlns:b="bravo"/>
-            """)
+            """
+        )
 
-        assert module_elem.namespace_map == {'a': 'alpha', 'b': 'bravo'}
+        assert module_elem.namespace_map == {"a": "alpha", "b": "bravo"}
 
     def test_description(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <description>
                     <text>
@@ -166,22 +183,26 @@ class TestYinElement(object):
                     </text>
                 </description>
             </module>
-            """)
+            """
+        )
 
         assert module_elem.description == (
-            'This is a long description of the data model that wraps onto the '
-            'next line'
+            "This is a long description of the data model that wraps onto the "
+            "next line"
         )
 
     def test_no_description(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert module_elem.description is None
 
     def test_child_data_definitions(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <namespace uri="test:ns"/>
                 <prefix value="t"/>
@@ -193,12 +214,14 @@ class TestYinElement(object):
                 <case/>
                 <anyxml/>
             </module>
-            """)
+            """
+        )
 
         assert len(list(module_elem.iterate_data_definitions())) == 7
 
     def test_rpc_definitions(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <namespace uri="test:ns"/>
                 <prefix value="t"/>
@@ -211,14 +234,16 @@ class TestYinElement(object):
                     <output/>
                 </rpc>
             </module>
-            """)
+            """
+        )
 
         assert len(list(module_elem.iterate_rpcs())) == 2
 
 
 @pytest.fixture
 def ancestor_data_node_model():
-    return yinsolidated.fromstring("""
+    return yinsolidated.fromstring(
+        """
         <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
             <namespace uri="test:ns"/>
             <prefix value="t"/>
@@ -239,412 +264,456 @@ def ancestor_data_node_model():
                 </list>
             </container>
         </module>
-        """)
+        """
+    )
 
 
 class TestGetAncestorDataNodes(object):
-
     def test_from_leaf_type(self, ancestor_data_node_model):
         type_elem = ancestor_data_node_model.find(
-            './/yin:leaf/yin:type',
-            namespaces=_NSMAP
+            ".//yin:leaf/yin:type", namespaces=_NSMAP
         )
 
         data_node_ancestors = type_elem.get_ancestor_data_nodes()
         assert len(data_node_ancestors) == 3
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
-        assert data_node_ancestors[2].keyword == 'leaf'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf"
 
     def test_from_leaf(self, ancestor_data_node_model):
-        leaf_elem = ancestor_data_node_model.find(
-            './/yin:leaf',
-            namespaces=_NSMAP
-        )
+        leaf_elem = ancestor_data_node_model.find(".//yin:leaf", namespaces=_NSMAP)
 
         data_node_ancestors = leaf_elem.get_ancestor_data_nodes()
         assert len(data_node_ancestors) == 2
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
 
     def test_from_leaf_list_type(self, ancestor_data_node_model):
         type_elem = ancestor_data_node_model.find(
-            './/yin:leaf-list/yin:type',
-            namespaces=_NSMAP
+            ".//yin:leaf-list/yin:type", namespaces=_NSMAP
         )
 
         data_node_ancestors = type_elem.get_ancestor_data_nodes()
         assert len(data_node_ancestors) == 3
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
-        assert data_node_ancestors[2].keyword == 'leaf-list'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf-list"
 
     def test_from_leaf_list(self, ancestor_data_node_model):
         leaf_list_elem = ancestor_data_node_model.find(
-            './/yin:leaf-list',
-            namespaces=_NSMAP
+            ".//yin:leaf-list", namespaces=_NSMAP
         )
 
         data_node_ancestors = leaf_list_elem.get_ancestor_data_nodes()
         assert len(data_node_ancestors) == 2
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
 
 
 class TestGetAncestorOrSelfDataNodes(object):
-
     def test_from_leaf_type(self, ancestor_data_node_model):
         type_elem = ancestor_data_node_model.find(
-            './/yin:leaf/yin:type',
-            namespaces=_NSMAP
+            ".//yin:leaf/yin:type", namespaces=_NSMAP
         )
 
         data_node_ancestors = type_elem.get_ancestor_or_self_data_nodes()
         assert len(data_node_ancestors) == 3
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
-        assert data_node_ancestors[2].keyword == 'leaf'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf"
 
     def test_from_leaf(self, ancestor_data_node_model):
-        leaf_elem = ancestor_data_node_model.find(
-            './/yin:leaf',
-            namespaces=_NSMAP
-        )
+        leaf_elem = ancestor_data_node_model.find(".//yin:leaf", namespaces=_NSMAP)
 
         data_node_ancestors = leaf_elem.get_ancestor_or_self_data_nodes()
         assert len(data_node_ancestors) == 3
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
-        assert data_node_ancestors[2].keyword == 'leaf'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf"
 
     def test_from_leaf_list_type(self, ancestor_data_node_model):
         type_elem = ancestor_data_node_model.find(
-            './/yin:leaf-list/yin:type',
-            namespaces=_NSMAP
+            ".//yin:leaf-list/yin:type", namespaces=_NSMAP
         )
 
         data_node_ancestors = type_elem.get_ancestor_or_self_data_nodes()
         assert len(data_node_ancestors) == 3
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
-        assert data_node_ancestors[2].keyword == 'leaf-list'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf-list"
 
     def test_from_leaf_list(self, ancestor_data_node_model):
         leaf_list_elem = ancestor_data_node_model.find(
-            './/yin:leaf-list',
-            namespaces=_NSMAP
+            ".//yin:leaf-list", namespaces=_NSMAP
         )
 
         data_node_ancestors = leaf_list_elem.get_ancestor_or_self_data_nodes()
         assert len(data_node_ancestors) == 3
-        assert data_node_ancestors[0].keyword == 'container'
-        assert data_node_ancestors[1].keyword == 'list'
-        assert data_node_ancestors[2].keyword == 'leaf-list'
+        assert data_node_ancestors[0].keyword == "container"
+        assert data_node_ancestors[1].keyword == "list"
+        assert data_node_ancestors[2].keyword == "leaf-list"
 
 
 class TestModuleElement(object):
-
     def test_name(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module name="test"
                     xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:t="test:ns"
                     module-prefix="t">
             </module>
-            """)
+            """
+        )
 
-        assert module_elem.name == 'test'
+        assert module_elem.name == "test"
 
 
 class TestDefinitionElement(object):
-
     def test_name(self):
-        choice_elem = yinsolidated.fromstring("""
+        choice_elem = yinsolidated.fromstring(
+            """
             <choice name="system"
                     xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
-        assert choice_elem.name == 'system'
+        assert choice_elem.name == "system"
 
     def test_status(self):
-        choice_elem = yinsolidated.fromstring("""
+        choice_elem = yinsolidated.fromstring(
+            """
             <choice name="system" xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <status value='obsolete'/>
             </choice>
-            """)
+            """
+        )
 
-        assert choice_elem.status == 'obsolete'
+        assert choice_elem.status == "obsolete"
 
     def test_default_status(self):
-        choice_elem = yinsolidated.fromstring("""
+        choice_elem = yinsolidated.fromstring(
+            """
             <choice name="system" xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
-        assert choice_elem.status == 'current'
+        assert choice_elem.status == "current"
 
 
 class TestRpcElement(object):
-
     def test_input(self):
-        rpc_elem = yinsolidated.fromstring("""
+        rpc_elem = yinsolidated.fromstring(
+            """
             <rpc xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <input/>
             </rpc>
-            """)
+            """
+        )
 
         assert rpc_elem.input is not None
 
     def test_output(self):
-        rpc_elem = yinsolidated.fromstring("""
+        rpc_elem = yinsolidated.fromstring(
+            """
             <rpc xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <output/>
             </rpc>
-            """)
+            """
+        )
 
         assert rpc_elem.output is not None
 
 
 class TestDataDefinitionElement(object):
-
     def test_is_config_false(self):
-        choice_elem = yinsolidated.fromstring("""
+        choice_elem = yinsolidated.fromstring(
+            """
             <choice xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <config value="false"/>
             </choice>
-            """)
+            """
+        )
 
         assert not choice_elem.is_config
 
     def test_is_config_no_parent(self):
-        choice_elem = yinsolidated.fromstring("""
+        choice_elem = yinsolidated.fromstring(
+            """
             <choice xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert choice_elem.is_config
 
     def test_is_config_parent_false(self):
-        choice_elem = yinsolidated.fromstring("""
+        choice_elem = yinsolidated.fromstring(
+            """
             <choice xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <config value="false"/>
                 <leaf/>
             </choice>
-            """)
+            """
+        )
         leaf_elem = choice_elem[1]
 
         assert not leaf_elem.is_config
 
     def test_when_elements(self):
-        container_elem = yinsolidated.fromstring("""
+        container_elem = yinsolidated.fromstring(
+            """
             <container xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <when condition="false"/>
                 <when condition="true"/>
             </container>
-            """)
+            """
+        )
 
         assert len(container_elem.when_elements) == 2
 
 
 class TestContainerElement(object):
-
     def test_presence(self):
-        container_elem = yinsolidated.fromstring("""
+        container_elem = yinsolidated.fromstring(
+            """
             <container xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <presence value="My existence is meaningful"/>
             </container>
-            """)
+            """
+        )
 
-        assert container_elem.presence == 'My existence is meaningful'
+        assert container_elem.presence == "My existence is meaningful"
 
     def test_no_presence(self):
-        container_elem = yinsolidated.fromstring("""
+        container_elem = yinsolidated.fromstring(
+            """
             <container xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert container_elem.presence is None
 
 
 class TestLeafElement(object):
-
     def test_type(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <type name="uint8"/>
             </leaf>
-            """)
+            """
+        )
 
-        assert leaf_elem.type.base_type.name == 'uint8'
+        assert leaf_elem.type.base_type.name == "uint8"
 
     def test_default(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <default value="600"/>
             </leaf>
-            """)
+            """
+        )
 
-        assert leaf_elem.default == '600'
+        assert leaf_elem.default == "600"
 
     def test_no_default(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert leaf_elem.default is None
 
     def test_units(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <units name="seconds"/>
             </leaf>
-            """)
+            """
+        )
 
-        assert leaf_elem.units == 'seconds'
+        assert leaf_elem.units == "seconds"
 
     def test_no_units(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert leaf_elem.units is None
 
     def test_is_mandatory(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <mandatory value="true"/>
             </leaf>
-            """)
+            """
+        )
 
         assert leaf_elem.is_mandatory
 
     def test_not_mandatory(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <mandatory value="false"/>
             </leaf>
-            """)
+            """
+        )
 
         assert not leaf_elem.is_mandatory
 
     def test_not_mandatory_implicit(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert not leaf_elem.is_mandatory
 
     def test_is_list_key(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   xmlns:test="test:ns"
                   module-prefix="test">
                 <key value="alpha"/>
                 <leaf name="alpha"/>
             </list>
-            """)
-        leaf_elem = list_elem.find('yin:leaf', namespaces=_NSMAP)
+            """
+        )
+        leaf_elem = list_elem.find("yin:leaf", namespaces=_NSMAP)
 
         assert leaf_elem.is_list_key
 
     def test_list_child_not_key(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   xmlns:test="test:ns"
                   module-prefix="test">
                 <key value="alpha"/>
                 <leaf name="bravo"/>
             </list>
-            """)
-        leaf_elem = list_elem.find('yin:leaf', namespaces=_NSMAP)
+            """
+        )
+        leaf_elem = list_elem.find("yin:leaf", namespaces=_NSMAP)
 
         assert not leaf_elem.is_list_key
 
     def test_non_list_child_not_key(self):
-        leaf_elem = yinsolidated.fromstring("""
+        leaf_elem = yinsolidated.fromstring(
+            """
             <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert not leaf_elem.is_list_key
 
 
 class TestLeafListElement(object):
-
     def test_type(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <type name="uint8"/>
             </leaf-list>
-            """)
+            """
+        )
 
-        assert leaf_list_elem.type.base_type.name == 'uint8'
+        assert leaf_list_elem.type.base_type.name == "uint8"
 
     def test_units(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <units name="seconds"/>
             </leaf-list>
-            """)
+            """
+        )
 
-        assert leaf_list_elem.units == 'seconds'
+        assert leaf_list_elem.units == "seconds"
 
     def test_no_units(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert leaf_list_elem.units is None
 
     def test_min_elements(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <min-elements value="10"/>
             </leaf-list>
-            """)
+            """
+        )
 
         assert leaf_list_elem.min_elements == 10
 
     def test_no_min_elements(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert leaf_list_elem.min_elements == 0
 
     def test_max_elements(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <max-elements value="10"/>
             </leaf-list>
-            """)
+            """
+        )
 
         assert leaf_list_elem.max_elements == 10
 
     def test_no_max_elements(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert leaf_list_elem.max_elements is None
 
     def test_ordered_by_user(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <ordered-by value="user"/>
             </leaf-list>
-            """)
+            """
+        )
 
-        assert leaf_list_elem.ordered_by == 'user'
+        assert leaf_list_elem.ordered_by == "user"
 
     def test_no_ordered_by(self):
-        leaf_list_elem = yinsolidated.fromstring("""
+        leaf_list_elem = yinsolidated.fromstring(
+            """
             <leaf-list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
-        assert leaf_list_elem.ordered_by == 'system'
+        assert leaf_list_elem.ordered_by == "system"
 
 
 class TestListElement(object):
-
     def test_keys(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:a="alpha:ns"
                     xmlns:b="bravo:ns"
@@ -654,111 +723,134 @@ class TestListElement(object):
                     <key value="a:alpha b:bravo charlie"/>
                 </list>
             </module>
-            """)
-        list_elem = module_elem.find('yin:list', namespaces=_NSMAP)
+            """
+        )
+        list_elem = module_elem.find("yin:list", namespaces=_NSMAP)
 
         assert list_elem.key_ids == [
-            ('alpha', 'alpha:ns'),
-            ('bravo', 'bravo:ns'),
-            ('charlie', 'charlie:ns')
+            ("alpha", "alpha:ns"),
+            ("bravo", "bravo:ns"),
+            ("charlie", "charlie:ns"),
         ]
 
     def test_no_keys(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert list_elem.key_ids == []
 
     def test_unique(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <unique tag="alpha bravo charlie"/>
             </list>
-            """)
+            """
+        )
 
-        assert list_elem.unique == ['alpha', 'bravo', 'charlie']
+        assert list_elem.unique == ["alpha", "bravo", "charlie"]
 
     def test_min_elements(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <min-elements value="10"/>
             </list>
-            """)
+            """
+        )
 
         assert list_elem.min_elements == 10
 
     def test_no_min_elements(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert list_elem.min_elements == 0
 
     def test_max_elements(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <max-elements value="10"/>
             </list>
-            """)
+            """
+        )
 
         assert list_elem.max_elements == 10
 
     def test_no_max_elements(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert list_elem.max_elements is None
 
     def test_ordered_by_user(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <ordered-by value="user"/>
             </list>
-            """)
+            """
+        )
 
-        assert list_elem.ordered_by == 'user'
+        assert list_elem.ordered_by == "user"
 
     def test_no_ordered_by(self):
-        list_elem = yinsolidated.fromstring("""
+        list_elem = yinsolidated.fromstring(
+            """
             <list xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
-        assert list_elem.ordered_by == 'system'
+        assert list_elem.ordered_by == "system"
 
 
 class TestAnyxmlElement(object):
-
     def test_is_mandatory(self):
-        anyxml_elem = yinsolidated.fromstring("""
+        anyxml_elem = yinsolidated.fromstring(
+            """
             <anyxml xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <mandatory value="true"/>
             </anyxml>
-            """)
+            """
+        )
 
         assert anyxml_elem.is_mandatory
 
     def test_not_mandatory(self):
-        anyxml_elem = yinsolidated.fromstring("""
+        anyxml_elem = yinsolidated.fromstring(
+            """
             <anyxml xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <mandatory value="false"/>
             </anyxml>
-            """)
+            """
+        )
 
         assert not anyxml_elem.is_mandatory
 
     def test_not_mandatory_implicit(self):
-        anyxml_elem = yinsolidated.fromstring("""
+        anyxml_elem = yinsolidated.fromstring(
+            """
             <anyxml xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert not anyxml_elem.is_mandatory
 
 
 @pytest.fixture
 def type_elem_with_unprefixed_name():
-    return yinsolidated.fromstring("""
+    return yinsolidated.fromstring(
+        """
         <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1"
               xmlns:a="a:ns"
               module-prefix="a"
@@ -769,25 +861,26 @@ def type_elem_with_unprefixed_name():
                 </typedef>
             </type>
         </leaf>
-        """).find('yin:type', _NSMAP)
+        """
+    ).find("yin:type", _NSMAP)
 
 
 class TestTypeElement(object):
-
     def test_name(self, type_elem_with_unprefixed_name):
-        assert type_elem_with_unprefixed_name.name == 'counter'
+        assert type_elem_with_unprefixed_name.name == "counter"
 
     def test_unprefixed_name(self, type_elem_with_unprefixed_name):
-        assert type_elem_with_unprefixed_name.unprefixed_name == 'counter'
+        assert type_elem_with_unprefixed_name.unprefixed_name == "counter"
 
     def test_prefix(self, type_elem_with_unprefixed_name):
-        assert type_elem_with_unprefixed_name.prefix == 'a'
+        assert type_elem_with_unprefixed_name.prefix == "a"
 
     def test_namespace(self, type_elem_with_unprefixed_name):
-        assert type_elem_with_unprefixed_name.namespace == 'a:ns'
+        assert type_elem_with_unprefixed_name.namespace == "a:ns"
 
     def test_base(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="counter">
                 <typedef name="percentage">
@@ -799,12 +892,14 @@ class TestTypeElement(object):
                     <range value="0..100"/>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.base_type.name == 'uint8'
+        assert type_elem.base_type.name == "uint8"
 
     def test_base_for_leafref(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="test-leafref">
                 <typedef name="test-leafref">
@@ -813,12 +908,14 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.base_type.name == 'leafref'
+        assert type_elem.base_type.name == "leafref"
 
     def test_base_for_union(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="test-union">
                 <typedef name="test-union">
@@ -828,44 +925,52 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.base_type.name == 'union'
+        assert type_elem.base_type.name == "union"
 
     def test_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="counter">
                 <typedef name="counter">
                     <type name="uint32"/>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
         assert type_elem.typedef is not None
 
     def test_no_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="uint32"/>
-            """)
+            """
+        )
 
         assert type_elem.typedef is None
 
     def test_bits(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="bits">
                 <bit name="alpha"/>
                 <bit name="bravo"/>
             </type>
-            """)
+            """
+        )
 
         bit_names = [bit.name for bit in type_elem.bits]
-        assert bit_names == ['alpha', 'bravo']
+        assert bit_names == ["alpha", "bravo"]
 
     def test_bits_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -875,25 +980,29 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
         bit_names = [bit.name for bit in type_elem.bits]
-        assert bit_names == ['alpha', 'bravo']
+        assert bit_names == ["alpha", "bravo"]
 
     def test_enums(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="enumeration">
                 <enum name="alpha"/>
                 <enum name="bravo"/>
             </type>
-            """)
+            """
+        )
 
         enum_names = [enum.name for enum in type_elem.enums]
-        assert enum_names == ['alpha', 'bravo']
+        assert enum_names == ["alpha", "bravo"]
 
     def test_enums_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -903,23 +1012,27 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
         enum_names = [enum.name for enum in type_elem.enums]
-        assert enum_names == ['alpha', 'bravo']
+        assert enum_names == ["alpha", "bravo"]
 
     def test_fraction_digits(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="decimal64">
                 <fraction-digits value="2"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.fraction_digits == '2'
+        assert type_elem.fraction_digits == "2"
 
     def test_fraction_digits_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -928,31 +1041,37 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.fraction_digits == '2'
+        assert type_elem.fraction_digits == "2"
 
     def test_no_fraction_digits(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="string">
             </type>
-            """)
+            """
+        )
 
         assert type_elem.fraction_digits is None
 
     def test_base_identity(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="identityref">
                 <base name="base-identity"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.base_identity == 'base-identity'
+        assert type_elem.base_identity == "base-identity"
 
     def test_base_identity_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -961,12 +1080,14 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.base_identity == 'base-identity'
+        assert type_elem.base_identity == "base-identity"
 
     def test_identities_base_in_same_namespace(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:t="test:ns"
                     module-prefix="t">
@@ -998,17 +1119,19 @@ class TestTypeElement(object):
                     </type>
                 </leaf>
             </module>
-            """)
-        type_elem = module_elem.find('yin:leaf/yin:type', namespaces=_NSMAP)
+            """
+        )
+        type_elem = module_elem.find("yin:leaf/yin:type", namespaces=_NSMAP)
 
         identities = type_elem.get_identities()
 
         assert len(identities) == 2
-        assert identities[0].name == 'derived-identity'
-        assert identities[1].name == 'nested-derived-identity'
+        assert identities[0].name == "derived-identity"
+        assert identities[1].name == "nested-derived-identity"
 
     def test_identities_base_in_different_namespace(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:t="test:ns"
                     module-prefix="t">
@@ -1036,16 +1159,18 @@ class TestTypeElement(object):
                     </type>
                 </leaf>
             </module>
-            """)
-        type_elem = module_elem.find('yin:leaf/yin:type', namespaces=_NSMAP)
+            """
+        )
+        type_elem = module_elem.find("yin:leaf/yin:type", namespaces=_NSMAP)
 
         identities = type_elem.get_identities()
 
         assert len(identities) == 1
-        assert identities[0].name == 'another-derived-identity'
+        assert identities[0].name == "another-derived-identity"
 
     def test_missing_identity(self):
-        module_elem = yinsolidated.fromstring("""
+        module_elem = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                     xmlns:t="test:ns"
                     module-prefix="t">
@@ -1056,33 +1181,39 @@ class TestTypeElement(object):
                     </type>
                 </leaf>
             </module>
-            """)
-        type_elem = module_elem.find('yin:leaf/yin:type', namespaces=_NSMAP)
+            """
+        )
+        type_elem = module_elem.find("yin:leaf/yin:type", namespaces=_NSMAP)
 
         with pytest.raises(yinsolidated.MissingIdentityError):
             type_elem.get_identities()
 
     def test_no_identities(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="string">
             </type>
-            """)
+            """
+        )
 
         assert len(type_elem.get_identities()) == 0
 
     def test_length(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="string">
                 <length value="1..253"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.length == '1..253'
+        assert type_elem.length == "1..253"
 
     def test_length_typedefs(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1091,11 +1222,13 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.length == '1..253'
+        assert type_elem.length == "1..253"
 
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="indirected-fake-type">
@@ -1107,11 +1240,13 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.length == '8..110'
+        assert type_elem.length == "8..110"
 
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1121,29 +1256,35 @@ class TestTypeElement(object):
                 </typedef>
                 <length value="9..17"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.length == '9..17'
+        assert type_elem.length == "9..17"
 
     def test_no_length(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1" name="string"/>
-            """)
+            """
+        )
 
         assert type_elem.length is None
 
     def test_path(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="leafref">
                 <path value="/a/fake/path"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.path == '/a/fake/path'
+        assert type_elem.path == "/a/fake/path"
 
     def test_path_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1152,19 +1293,23 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.path == '/a/fake/path'
+        assert type_elem.path == "/a/fake/path"
 
     def test_no_path(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1" name="string"/>
-            """)
+            """
+        )
 
         assert type_elem.path is None
 
     def test_patterns(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="string">
                 <pattern value="[a-zA-Z0-9_\\-]*">
@@ -1174,18 +1319,20 @@ class TestTypeElement(object):
                 </pattern>
                 <pattern value=".*"/>
             </type>
-            """)
+            """
+        )
 
         assert len(type_elem.patterns) == 2
 
-        assert type_elem.patterns[0].value == r'[a-zA-Z0-9_\-]*'
-        assert type_elem.patterns[0].error_message == 'Must be alphanumeric'
+        assert type_elem.patterns[0].value == r"[a-zA-Z0-9_\-]*"
+        assert type_elem.patterns[0].error_message == "Must be alphanumeric"
 
-        assert type_elem.patterns[1].value == '.*'
+        assert type_elem.patterns[1].value == ".*"
         assert type_elem.patterns[1].error_message is None
 
     def test_patterns_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1199,28 +1346,32 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
         assert len(type_elem.patterns) == 2
 
-        assert type_elem.patterns[0].value == r'[a-zA-Z0-9_\-]*'
-        assert type_elem.patterns[0].error_message == 'Must be alphanumeric'
+        assert type_elem.patterns[0].value == r"[a-zA-Z0-9_\-]*"
+        assert type_elem.patterns[0].error_message == "Must be alphanumeric"
 
-        assert type_elem.patterns[1].value == '.*'
+        assert type_elem.patterns[1].value == ".*"
         assert type_elem.patterns[1].error_message is None
 
     def test_range(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="uint8">
                 <range value="1..253"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.range == '1..253'
+        assert type_elem.range == "1..253"
 
     def test_range_typedefs(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1229,11 +1380,13 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.range == '1..253'
+        assert type_elem.range == "1..253"
 
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1245,11 +1398,13 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.range == '7..9'
+        assert type_elem.range == "7..9"
 
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1259,41 +1414,49 @@ class TestTypeElement(object):
                 </typedef>
                 <range value="4..128"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.range == '4..128'
+        assert type_elem.range == "4..128"
 
     def test_no_range(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="uint8"/>
-            """)
+            """
+        )
 
         assert type_elem.range is None
 
     def test_referenced_type_for_leafref(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="leafref">
                 <type name="string"/>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.referenced_type.base_type.name == 'string'
+        assert type_elem.referenced_type.base_type.name == "string"
 
     def test_referenced_type_for_union(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="union">
                 <type name="uint8"/>
                 <type name="string"/>
             </type>
-            """)
+            """
+        )
 
         assert type_elem.referenced_type is None
 
     def test_referenced_type_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1302,34 +1465,40 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
-        assert type_elem.referenced_type.base_type.name == 'string'
+        assert type_elem.referenced_type.base_type.name == "string"
 
     def test_subtypes_for_union(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="union">
                 <type name="uint8"/>
                 <type name="string"/>
             </type>
-            """)
+            """
+        )
 
         subtype_names = [elem.base_type.name for elem in type_elem.subtypes]
-        assert subtype_names == ['uint8', 'string']
+        assert subtype_names == ["uint8", "string"]
 
     def test_subtypes_for_leafref(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="leafref">
                 <type name="uint8"/>
             </type>
-            """)
+            """
+        )
 
         assert len(type_elem.subtypes) == 0
 
     def test_subtypes_typedef(self):
-        type_elem = yinsolidated.fromstring("""
+        type_elem = yinsolidated.fromstring(
+            """
             <type xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="fake-type">
                 <typedef name="fake-type">
@@ -1339,15 +1508,17 @@ class TestTypeElement(object):
                     </type>
                 </typedef>
             </type>
-            """)
+            """
+        )
 
         subtype_names = [elem.base_type.name for elem in type_elem.subtypes]
-        assert subtype_names == ['uint8', 'string']
+        assert subtype_names == ["uint8", "string"]
 
 
 @pytest.fixture
 def type_elem_with_prefixed_name():
-    return yinsolidated.fromstring("""
+    return yinsolidated.fromstring(
+        """
         <leaf xmlns="urn:ietf:params:xml:ns:yang:yin:1"
               xmlns:a="a:ns"
               xmlns:b="b:ns"
@@ -1359,240 +1530,275 @@ def type_elem_with_prefixed_name():
                 </typedef>
             </type>
         </leaf>
-        """).find('yin:type', _NSMAP)
+        """
+    ).find("yin:type", _NSMAP)
 
 
 class TestTypeElementWithPrefixedName(object):
-
     def test_name(self, type_elem_with_prefixed_name):
-        assert type_elem_with_prefixed_name.name == 'b:counter'
+        assert type_elem_with_prefixed_name.name == "b:counter"
 
     def test_unprefixed_name(self, type_elem_with_prefixed_name):
-        assert type_elem_with_prefixed_name.unprefixed_name == 'counter'
+        assert type_elem_with_prefixed_name.unprefixed_name == "counter"
 
     def test_prefix(self, type_elem_with_prefixed_name):
-        assert type_elem_with_prefixed_name.prefix == 'b'
+        assert type_elem_with_prefixed_name.prefix == "b"
 
     def test_namespace(self, type_elem_with_prefixed_name):
-        assert type_elem_with_prefixed_name.namespace == 'b:ns'
+        assert type_elem_with_prefixed_name.namespace == "b:ns"
 
 
 class TestTypedefElement(object):
-
     def test_name(self):
-        typedef_elem = yinsolidated.fromstring("""
+        typedef_elem = yinsolidated.fromstring(
+            """
             <typedef xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                      name="counter">
             </typedef>
-            """)
+            """
+        )
 
-        assert typedef_elem.name == 'counter'
+        assert typedef_elem.name == "counter"
 
     def test_type(self):
-        typedef_elem = yinsolidated.fromstring("""
+        typedef_elem = yinsolidated.fromstring(
+            """
             <typedef xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                      name="counter">
                 <type name="uint32"/>
             </typedef>
-            """)
+            """
+        )
 
-        assert typedef_elem.type.name == 'uint32'
+        assert typedef_elem.type.name == "uint32"
 
     def test_default(self):
-        typedef_elem = yinsolidated.fromstring("""
+        typedef_elem = yinsolidated.fromstring(
+            """
             <typedef xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                      name="counter">
                 <default value="600"/>
             </typedef>
-            """)
+            """
+        )
 
-        assert typedef_elem.default == '600'
+        assert typedef_elem.default == "600"
 
     def test_no_default(self):
-        typedef_elem = yinsolidated.fromstring("""
+        typedef_elem = yinsolidated.fromstring(
+            """
             <typedef xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                      name="counter"/>
-            """)
+            """
+        )
 
         assert typedef_elem.default is None
 
     def test_units(self):
-        typedef_elem = yinsolidated.fromstring("""
+        typedef_elem = yinsolidated.fromstring(
+            """
             <typedef xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                      name="counter">
                 <units name="seconds"/>
             </typedef>
-            """)
+            """
+        )
 
-        assert typedef_elem.units == 'seconds'
+        assert typedef_elem.units == "seconds"
 
     def test_no_units(self):
-        typedef_elem = yinsolidated.fromstring("""
+        typedef_elem = yinsolidated.fromstring(
+            """
             <typedef xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                      name="counter"/>
-            """)
+            """
+        )
 
         assert typedef_elem.units is None
 
 
 class TestBitElement(object):
-
     def test_name(self):
-        bit_elem = yinsolidated.fromstring("""
+        bit_elem = yinsolidated.fromstring(
+            """
             <bit xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                  name="alpha"/>
-            """)
+            """
+        )
 
-        assert bit_elem.name == 'alpha'
+        assert bit_elem.name == "alpha"
 
     def test_position(self):
-        bit_elem = yinsolidated.fromstring("""
+        bit_elem = yinsolidated.fromstring(
+            """
             <bit xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <position value="1"/>
             </bit>
-            """)
+            """
+        )
 
         assert bit_elem.position == 1
 
     def test_no_position(self):
-        bit_elem = yinsolidated.fromstring("""
+        bit_elem = yinsolidated.fromstring(
+            """
             <bit xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert bit_elem.position is None
 
 
 class TestEnumElement(object):
-
     def test_name(self):
-        enum_elem = yinsolidated.fromstring("""
+        enum_elem = yinsolidated.fromstring(
+            """
             <enum xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   name="alpha"/>
-            """)
+            """
+        )
 
-        assert enum_elem.name == 'alpha'
+        assert enum_elem.name == "alpha"
 
     def test_value(self):
-        enum_elem = yinsolidated.fromstring("""
+        enum_elem = yinsolidated.fromstring(
+            """
             <enum xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <value value="1"/>
             </enum>
-            """)
+            """
+        )
 
         assert enum_elem.value == 1
 
     def test_no_value(self):
-        enum_elem = yinsolidated.fromstring("""
+        enum_elem = yinsolidated.fromstring(
+            """
             <enum xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert enum_elem.value is None
 
 
 class TestWhenElement(object):
-
     def test_no_prefix_added(self):
-        container_elem = yinsolidated.fromstring("""
+        container_elem = yinsolidated.fromstring(
+            """
             <container xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                        xmlns:t="test:ns"
                        module-prefix="t">
                 <when condition="t:foo = 'bar'"/>
             </container>
-            """)
-        when_element = container_elem.find('yin:when', namespaces=_NSMAP)
+            """
+        )
+        when_element = container_elem.find("yin:when", namespaces=_NSMAP)
 
         assert when_element.condition == "t:foo = 'bar'"
-        assert when_element.namespace_map == {'t': 'test:ns'}
+        assert when_element.namespace_map == {"t": "test:ns"}
 
     def test_prefix_added(self):
-        container_elem = yinsolidated.fromstring("""
+        container_elem = yinsolidated.fromstring(
+            """
             <container xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                        xmlns:d="default:ns"
                        xmlns:t="test:ns"
                        module-prefix="d">
                 <when condition="../foo/bar = 'alpha' | /t:root/test = 'bravo'"/>
             </container>
-            """)  # nopep8
+            """
+        )  # nopep8
 
-        when_element = container_elem.find('yin:when', namespaces=_NSMAP)
+        when_element = container_elem.find("yin:when", namespaces=_NSMAP)
 
         assert when_element.condition == (
             "../d:foo/d:bar = 'alpha' | /t:root/d:test = 'bravo'"
         )
 
-        assert when_element.namespace_map == {
-            'd': 'default:ns',
-            't': 'test:ns'
-        }
+        assert when_element.namespace_map == {"d": "default:ns", "t": "test:ns"}
 
     def test_self_context(self):
-        when_element = yinsolidated.fromstring("""
+        when_element = yinsolidated.fromstring(
+            """
             <when xmlns="urn:ietf:params:xml:ns:yang:yin:1"/>
-            """)
+            """
+        )
 
         assert not when_element.context_node_is_parent
 
     def test_parent_context(self):
-        when_element = yinsolidated.fromstring("""
+        when_element = yinsolidated.fromstring(
+            """
             <when xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                   context-node="parent"/>
-            """)
+            """
+        )
 
         assert when_element.context_node_is_parent
 
 
 class TestIdentityElement(object):
-
     def test_name(self):
-        identity_elem = yinsolidated.fromstring("""
+        identity_elem = yinsolidated.fromstring(
+            """
             <identity xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                       name="test-identity"/>
-            """)
+            """
+        )
 
-        assert identity_elem.name == 'test-identity'
+        assert identity_elem.name == "test-identity"
 
     def test_namespace(self):
-        identity_elem = yinsolidated.fromstring("""
+        identity_elem = yinsolidated.fromstring(
+            """
             <identity xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                       xmlns:t="test:ns"
                       module-prefix="t"
                       name="test-identity"/>
-            """)
+            """
+        )
 
-        assert identity_elem.namespace == 'test:ns'
+        assert identity_elem.namespace == "test:ns"
 
     def test_prefix(self):
-        identity_elem = yinsolidated.fromstring("""
+        identity_elem = yinsolidated.fromstring(
+            """
             <identity xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                       xmlns:t="test:ns"
                       module-prefix="t"
                       name="test-identity"/>
-            """)
+            """
+        )
 
-        assert identity_elem.prefix == 't'
+        assert identity_elem.prefix == "t"
 
     def test_no_base(self):
-        identity_elem = yinsolidated.fromstring("""
+        identity_elem = yinsolidated.fromstring(
+            """
             <identity xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                       name="test-identity"/>
-            """)
+            """
+        )
 
         assert identity_elem.base == (None, None)
 
     def test_base_in_same_namespace(self):
-        identity_elem = yinsolidated.fromstring("""
+        identity_elem = yinsolidated.fromstring(
+            """
             <identity xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                       xmlns:t="test:ns"
                       module-prefix="t"
                       name="test-identity">
                 <base name="base-identity"/>
             </identity>
-            """)
+            """
+        )
 
-        assert identity_elem.base == ('base-identity', 'test:ns')
+        assert identity_elem.base == ("base-identity", "test:ns")
 
     def test_base_in_different_namespace(self):
-        identity_elem = yinsolidated.fromstring("""
+        identity_elem = yinsolidated.fromstring(
+            """
             <identity xmlns="urn:ietf:params:xml:ns:yang:yin:1"
                       xmlns:t="test:ns"
                       xmlns:o="other:ns"
@@ -1600,12 +1806,14 @@ class TestIdentityElement(object):
                       name="test-identity">
                 <base name="o:base-identity"/>
             </identity>
-            """)
+            """
+        )
 
-        assert identity_elem.base == ('base-identity', 'other:ns')
+        assert identity_elem.base == ("base-identity", "other:ns")
 
     def test_iterate_derived_identities(self):
-        module_element = yinsolidated.fromstring("""
+        module_element = yinsolidated.fromstring(
+            """
             <module xmlns="urn:ietf:params:xml:ns:yang:yin:1">
                 <identity xmlns:t="test:ns"
                           module-prefix="t"
@@ -1640,19 +1848,20 @@ class TestIdentityElement(object):
                     <base name="o:external-derived-identity"/>
                 </identity>
             </module>
-            """)
-        base_identity = module_element.find('yin:identity', namespaces=_NSMAP)
-        assert base_identity.name == 'base-identity'
+            """
+        )
+        base_identity = module_element.find("yin:identity", namespaces=_NSMAP)
+        assert base_identity.name == "base-identity"
 
         derived_identities = base_identity.get_derived_identities()
 
         assert len(derived_identities) == 3
-        assert derived_identities[0].name == 'derived-identity-1'
-        assert derived_identities[1].name == 'external-derived-identity'
-        assert derived_identities[2].name == 'nested-derived-identity'
+        assert derived_identities[0].name == "derived-identity-1"
+        assert derived_identities[1].name == "external-derived-identity"
+        assert derived_identities[2].name == "nested-derived-identity"
 
         direct_identities = base_identity.get_directly_derived_identities()
 
         assert len(direct_identities) == 2
-        assert direct_identities[0].name == 'derived-identity-1'
-        assert direct_identities[1].name == 'external-derived-identity'
+        assert direct_identities[0].name == "derived-identity-1"
+        assert direct_identities[1].name == "external-derived-identity"

--- a/test/plugin_json_test.py
+++ b/test/plugin_json_test.py
@@ -1,0 +1,161 @@
+# Copyright 2016 128 Technology, Inc.
+
+"""Unit tests for the yinsolidated pyang plugin"""
+
+from __future__ import unicode_literals
+
+import json
+import os
+import subprocess
+
+import pyang
+import pytest
+
+from yinsolidated.plugin import plugin
+
+
+YINSOLIDATED_PLUGIN_DIRECTORY = os.path.dirname(plugin.__file__)
+
+YIN_NAMESPACE = "urn:ietf:params:xml:ns:yang:yin:1"
+TEST_NAMESPACE = "urn:xml:ns:test"
+AUGMENTING_NAMESPACE = "urn:xml:ns:test:augment"
+NSMAP = {"yin": YIN_NAMESPACE, "test": TEST_NAMESPACE, "aug": AUGMENTING_NAMESPACE}
+
+
+@pytest.fixture(scope="module")
+def consolidated_model():
+    test_file_dir = os.path.dirname(os.path.realpath(__file__))
+    modules_dir = os.path.join(test_file_dir, "modules")
+    main_module = os.path.join(modules_dir, "test-module.yang")
+    augmenting_module = os.path.join(modules_dir, "augmenting-module.yang")
+
+    pyang_command = [
+        "pyang",
+        "-f",
+        "yinsolidated",
+        "--yinsolidated-output-format=json",
+        "-p",
+        modules_dir,
+    ]
+
+    if pyang.__version__ < "1.7.2":
+        pyang_command.extend(["--plugindir", YINSOLIDATED_PLUGIN_DIRECTORY])
+
+    pyang_command.extend([main_module, augmenting_module])
+
+    consolidated_model_json = subprocess.check_output(pyang_command)
+
+    return json.loads(consolidated_model_json)
+
+
+def get_nested(yin_element, *path):
+    path = list(path)
+    last = path.pop()
+    for key in path:
+        for child in yin_element["children"]:
+            if child["keyword"] == key:
+                yin_element = child
+                break
+        else:
+            raise KeyError(key)
+
+    return yin_element[last]
+
+
+class TestModule(object):
+    def test_module_root_element(self, consolidated_model):
+        assert consolidated_model["keyword"] == "module"
+
+    def test_module_name_attribute(self, consolidated_model):
+        module_name = consolidated_model.get("module-name")
+        assert module_name == "test-module"
+
+    def test_prefix_attribute(self, consolidated_model):
+        prefix = consolidated_model.get("module-prefix")
+        assert prefix == "test"
+
+    def test_nsmap(self, consolidated_model):
+        expected_nsmap = {"yin": YIN_NAMESPACE, "test": TEST_NAMESPACE}
+        assert consolidated_model["nsmap"] == expected_nsmap
+
+    def test_yang_version(self, consolidated_model):
+        yang_version = get_nested(consolidated_model, "yang-version", "value")
+        assert yang_version == "1"
+
+    def test_namespace(self, consolidated_model):
+        namespace = get_nested(consolidated_model, "namespace", "uri")
+        assert namespace == TEST_NAMESPACE
+
+    def test_prefix(self, consolidated_model):
+        prefix = get_nested(consolidated_model, "prefix", "value")
+        assert prefix == "test"
+
+    def test_organization(self, consolidated_model):
+        organization = get_nested(consolidated_model, "organization", "text")
+        assert organization == "None"
+
+    def test_contact(self, consolidated_model):
+        contact = get_nested(consolidated_model, "contact", "text")
+        assert contact == "Somebody"
+
+    def test_description(self, consolidated_model):
+        description = get_nested(consolidated_model, "description", "text")
+        assert (
+            description
+            == "Test module containing an exhaustive set of possible YANG statements"
+        )
+
+    def test_revision(self, consolidated_model):
+        date = get_nested(consolidated_model, "revision", "date")
+        assert date == "2016-04-22"
+
+        description = get_nested(consolidated_model, "revision", "description", "text")
+        assert description == "Initial revision"
+
+    def test_simple_extension_no_arg(self, consolidated_model):
+        name = get_nested(consolidated_model, "extension", "name")
+        assert name == "simple-extension-no-arg"
+
+        description = get_nested(consolidated_model, "extension", "description", "text")
+        assert (
+            description
+            == "An extension that takes no argument and does not support substatements"
+        )
+
+    def test_feature(self, consolidated_model):
+        name = get_nested(consolidated_model, "feature", "name")
+        assert name == "test-feature"
+
+        description = get_nested(consolidated_model, "feature", "description", "text")
+        assert description == "A test feature"
+
+
+class TestSubmodule(object):
+    def test_data_definitions_included(self, consolidated_model):
+        name = get_nested(consolidated_model, "container", "name")
+        assert name == "submodule-container"
+
+
+class TestEverything(object):
+    """
+    Rather than having a dozen tests that each compare one chunk of the consolidated
+    model at a time, why not compare the whole thing in one go!
+    """
+
+    @pytest.mark.skip(
+        "enable this 'test' to automatically re-generate the expected file"
+    )
+    def test_generate(self, consolidated_model):
+        with open(
+            os.path.join(os.path.dirname(__file__), "expected.json"), "w"
+        ) as file_:
+            json.dump(consolidated_model, file_, indent=2)
+        assert False
+
+    def test_everything(self, consolidated_model):
+        with open(
+            os.path.join(os.path.dirname(__file__), "expected.json"), "r"
+        ) as file_:
+            expected = json.load(file_)
+
+        assert consolidated_model == expected

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -16,31 +16,29 @@ from yinsolidated.plugin import plugin
 
 YINSOLIDATED_PLUGIN_DIRECTORY = os.path.dirname(plugin.__file__)
 
-YIN_NAMESPACE = 'urn:ietf:params:xml:ns:yang:yin:1'
-TEST_NAMESPACE = 'urn:xml:ns:test'
-AUGMENTING_NAMESPACE = 'urn:xml:ns:test:augment'
-NSMAP = {
-    'yin': YIN_NAMESPACE,
-    'test': TEST_NAMESPACE,
-    'aug': AUGMENTING_NAMESPACE
-}
+YIN_NAMESPACE = "urn:ietf:params:xml:ns:yang:yin:1"
+TEST_NAMESPACE = "urn:xml:ns:test"
+AUGMENTING_NAMESPACE = "urn:xml:ns:test:augment"
+NSMAP = {"yin": YIN_NAMESPACE, "test": TEST_NAMESPACE, "aug": AUGMENTING_NAMESPACE}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def consolidated_model():
     test_file_dir = os.path.dirname(os.path.realpath(__file__))
-    modules_dir = os.path.join(test_file_dir, 'modules')
-    main_module = os.path.join(modules_dir, 'test-module.yang')
-    augmenting_module = os.path.join(modules_dir, 'augmenting-module.yang')
+    modules_dir = os.path.join(test_file_dir, "modules")
+    main_module = os.path.join(modules_dir, "test-module.yang")
+    augmenting_module = os.path.join(modules_dir, "augmenting-module.yang")
 
     pyang_command = [
-        'pyang',
-        '-f', 'yinsolidated',
-        '-p', modules_dir,
+        "pyang",
+        "-f",
+        "yinsolidated",
+        "-p",
+        modules_dir,
     ]
 
-    if pyang.__version__ < '1.7.2':
-        pyang_command.extend(['--plugindir', YINSOLIDATED_PLUGIN_DIRECTORY])
+    if pyang.__version__ < "1.7.2":
+        pyang_command.extend(["--plugindir", YINSOLIDATED_PLUGIN_DIRECTORY])
 
     pyang_command.extend([main_module, augmenting_module])
 
@@ -53,102 +51,97 @@ _XML_CHECKER = doctestcompare.LXMLOutputChecker()
 
 
 def assert_xml_equal(expected, actual):
-    assert _XML_CHECKER.check_output(
-        expected,
-        actual,
-        doctestcompare.PARSE_XML
-    ), 'XML is not equivalent:\n' + _XML_CHECKER.output_difference(
-        StupidExampleWrapper(expected),
-        actual,
-        doctestcompare.PARSE_XML
+    assert _XML_CHECKER.check_output(expected, actual, doctestcompare.PARSE_XML), (
+        "XML is not equivalent:\n"
+        + _XML_CHECKER.output_difference(
+            StupidExampleWrapper(expected), actual, doctestcompare.PARSE_XML
+        )
     )
 
 
 class StupidExampleWrapper(object):
-
     def __init__(self, xml):
         self.want = xml
 
 
 class TestModule(object):
-
     def test_module_root_element(self, consolidated_model):
         qname = etree.QName(consolidated_model.tag)
-        assert qname.localname == 'module'
+        assert qname.localname == "module"
         assert qname.namespace == YIN_NAMESPACE
 
     def test_module_name_attribute(self, consolidated_model):
-        module_name = consolidated_model.get('module-name')
-        assert module_name == 'test-module'
+        module_name = consolidated_model.get("module-name")
+        assert module_name == "test-module"
 
     def test_prefix_attribute(self, consolidated_model):
-        prefix = consolidated_model.get('module-prefix')
-        assert prefix == 'test'
+        prefix = consolidated_model.get("module-prefix")
+        assert prefix == "test"
 
     def test_nsmap(self, consolidated_model):
-        expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE
-        }
+        expected_nsmap = {"yin": YIN_NAMESPACE, "test": TEST_NAMESPACE}
         assert consolidated_model.nsmap == expected_nsmap
 
     def test_yang_version(self, consolidated_model):
         yang_version = consolidated_model.xpath(
-            'yin:yang-version/@value', namespaces=NSMAP)[0]
-        assert yang_version == '1'
+            "yin:yang-version/@value", namespaces=NSMAP
+        )[0]
+        assert yang_version == "1"
 
     def test_namespace(self, consolidated_model):
-        namespace = consolidated_model.xpath(
-            'yin:namespace/@uri', namespaces=NSMAP)[0]
+        namespace = consolidated_model.xpath("yin:namespace/@uri", namespaces=NSMAP)[0]
         assert namespace == TEST_NAMESPACE
 
     def test_prefix(self, consolidated_model):
-        prefix = consolidated_model.xpath(
-            'yin:prefix/@value', namespaces=NSMAP)[0]
-        assert prefix == 'test'
+        prefix = consolidated_model.xpath("yin:prefix/@value", namespaces=NSMAP)[0]
+        assert prefix == "test"
 
     def test_organization(self, consolidated_model):
         organization_elem = consolidated_model.find(
-            'yin:organization', namespaces=NSMAP)
+            "yin:organization", namespaces=NSMAP
+        )
         actual_xml = etree.tostring(organization_elem)
 
         expected_xml = """
             <organization xmlns="{yin}">
                 <text>None</text>
             </organization>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_contact(self, consolidated_model):
-        contact_elem = consolidated_model.find(
-            'yin:contact', namespaces=NSMAP)
+        contact_elem = consolidated_model.find("yin:contact", namespaces=NSMAP)
         actual_xml = etree.tostring(contact_elem)
 
         expected_xml = """
             <contact xmlns="{yin}">
                 <text>Somebody</text>
             </contact>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_description(self, consolidated_model):
-        description_elem = consolidated_model.find(
-            'yin:description', namespaces=NSMAP)
+        description_elem = consolidated_model.find("yin:description", namespaces=NSMAP)
         actual_xml = etree.tostring(description_elem)
 
         expected_xml = """
             <description xmlns="{yin}">
                 <text>Test module containing an exhaustive set of possible YANG statements</text>
             </description>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_revision(self, consolidated_model):
-        revision_elem = consolidated_model.find(
-            'yin:revision', namespaces=NSMAP)
+        revision_elem = consolidated_model.find("yin:revision", namespaces=NSMAP)
         actual_xml = etree.tostring(revision_elem)
 
         expected_xml = """
@@ -157,14 +150,15 @@ class TestModule(object):
                     <text>Initial revision</text>
                 </description>
             </revision>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_extension_definition(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'yin:extension[@name="simple-extension-element-arg"]',
-            namespaces=NSMAP
+            'yin:extension[@name="simple-extension-element-arg"]', namespaces=NSMAP
         )
 
         actual_xml = etree.tostring(extension_elem)
@@ -182,49 +176,61 @@ class TestModule(object):
                 </reference>
                 <status value="current"/>
             </extension>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_simple_extension_no_arg(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'test:simple-extension-no-arg', namespaces=NSMAP)
+            "test:simple-extension-no-arg", namespaces=NSMAP
+        )
 
         actual_xml = etree.tostring(extension_elem)
 
         expected_xml = """
             <test:simple-extension-no-arg xmlns:test="{test}"/>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_simple_extension_attribute_arg(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'test:simple-extension-attribute-arg', namespaces=NSMAP)
+            "test:simple-extension-attribute-arg", namespaces=NSMAP
+        )
 
         actual_xml = etree.tostring(extension_elem)
 
         expected_xml = """
             <test:simple-extension-attribute-arg xmlns:test="{test}">test-value</test:simple-extension-attribute-arg>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_simple_extension_element_arg(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'test:simple-extension-element-arg', namespaces=NSMAP)
+            "test:simple-extension-element-arg", namespaces=NSMAP
+        )
 
         actual_xml = etree.tostring(extension_elem)
 
         expected_xml = """
             <test:simple-extension-element-arg xmlns:test="{test}">test-value</test:simple-extension-element-arg>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_complex_extension_no_arg(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'test:complex-extension-no-arg', namespaces=NSMAP)
+            "test:complex-extension-no-arg", namespaces=NSMAP
+        )
 
         actual_xml = etree.tostring(extension_elem)
 
@@ -235,13 +241,16 @@ class TestModule(object):
                 </description>
                 <test:simple-extension-no-arg/>
             </test:complex-extension-no-arg>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_complex_extension_attribute_arg(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'test:complex-extension-attribute-arg', namespaces=NSMAP)
+            "test:complex-extension-attribute-arg", namespaces=NSMAP
+        )
 
         actual_xml = etree.tostring(extension_elem)
 
@@ -256,13 +265,16 @@ class TestModule(object):
                 </description>
                 <test:simple-extension-attribute-arg>test-value</test:simple-extension-attribute-arg>
             </test:complex-extension-attribute-arg>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_complex_extension_element_arg(self, consolidated_model):
         extension_elem = consolidated_model.find(
-            'test:complex-extension-element-arg', namespaces=NSMAP)
+            "test:complex-extension-element-arg", namespaces=NSMAP
+        )
 
         actual_xml = etree.tostring(extension_elem)
 
@@ -274,13 +286,14 @@ class TestModule(object):
                 </description>
                 <test:simple-extension-element-arg>test-value</test:simple-extension-element-arg>
             </test:complex-extension-element-arg>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_feature(self, consolidated_model):
-        feature_elem = consolidated_model.find(
-            'yin:feature', namespaces=NSMAP)
+        feature_elem = consolidated_model.find("yin:feature", namespaces=NSMAP)
         actual_xml = etree.tostring(feature_elem)
 
         expected_xml = """
@@ -289,13 +302,16 @@ class TestModule(object):
                     <text>A test feature</text>
                 </description>
             </feature>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_base_identity(self, consolidated_model):
         base_identity_elem = consolidated_model.find(
-            'yin:identity[@name="test-base-identity"]', namespaces=NSMAP)
+            'yin:identity[@name="test-base-identity"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(base_identity_elem)
 
         expected_xml = """
@@ -312,14 +328,16 @@ class TestModule(object):
                 </reference>
                 <status value="current"/>
             </identity>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_identity_from_augmenting_module(self, consolidated_model):
         augmenting_identity_elem = consolidated_model.find(
-            'yin:identity[@name="augmenting-derived-identity"]',
-            namespaces=NSMAP)
+            'yin:identity[@name="augmenting-derived-identity"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_identity_elem)
 
         expected_xml = """
@@ -334,29 +352,30 @@ class TestModule(object):
                 </description>
                 <base name="t:test-base-identity"/>
             </identity>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_no_typedefs_added(self, consolidated_model):
-        typedef_elems = consolidated_model.findall(
-            'yin:typedef', namespaces=NSMAP)
+        typedef_elems = consolidated_model.findall("yin:typedef", namespaces=NSMAP)
         assert len(typedef_elems) == 0
 
 
 class TestSubmodule(object):
-
     def test_data_definitions_included(self, consolidated_model):
         submodule_container_elems = consolidated_model.findall(
-            'yin:container[@name="submodule-container"]', namespaces=NSMAP)
+            'yin:container[@name="submodule-container"]', namespaces=NSMAP
+        )
         assert len(submodule_container_elems) == 1
 
 
 class TestChoice(object):
-
     def test_choice(self, consolidated_model):
         choice_elem = consolidated_model.find(
-            'yin:choice[@name="root-choice"]', namespaces=NSMAP)
+            'yin:choice[@name="root-choice"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(choice_elem)
 
         expected_xml = """
@@ -426,16 +445,18 @@ class TestChoice(object):
                     </leaf>
                 </case>
             </choice>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestContainer(object):
-
     def test_container(self, consolidated_model):
         container_elem = consolidated_model.find(
-            'yin:container[@name="root-container"]', namespaces=NSMAP)
+            'yin:container[@name="root-container"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(container_elem)
 
         expected_xml = """
@@ -476,16 +497,18 @@ class TestContainer(object):
                     <type name="string"/>
                 </leaf>
             </container>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestLeaf(object):
-
     def test_leaf(self, consolidated_model):
         leaf_elem = consolidated_model.find(
-            'yin:leaf[@name="root-leaf"]', namespaces=NSMAP)
+            'yin:leaf[@name="root-leaf"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(leaf_elem)
 
         expected_xml = """
@@ -506,16 +529,18 @@ class TestLeaf(object):
                 <units name="goobers"/>
                 <when condition="count(../root-leaf-list) &gt; 0"/>
             </leaf>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestLeafList(object):
-
     def test_leaf_list(self, consolidated_model):
         leaf_list_elem = consolidated_model.find(
-            'yin:leaf-list[@name="root-leaf-list"]', namespaces=NSMAP)
+            'yin:leaf-list[@name="root-leaf-list"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(leaf_list_elem)
 
         expected_xml = """
@@ -537,16 +562,18 @@ class TestLeafList(object):
                 <units name="awesomeness"/>
                 <when condition="../root-leaf != 'nonsense'"/>
             </leaf-list>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestList(object):
-
     def test_list(self, consolidated_model):
         list_elem = consolidated_model.find(
-            'yin:list[@name="root-list"]', namespaces=NSMAP)
+            'yin:list[@name="root-list"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(list_elem)
 
         expected_xml = """
@@ -587,16 +614,18 @@ class TestList(object):
                     <type name="string"/>
                 </leaf>
             </list>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestUses(object):
-
     def test_grouped_choice(self, consolidated_model):
         grouped_choice_elem = consolidated_model.find(
-            'yin:choice[@name="grouped-choice"]', namespaces=NSMAP)
+            'yin:choice[@name="grouped-choice"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(grouped_choice_elem)
 
         expected_xml = """
@@ -605,13 +634,16 @@ class TestUses(object):
                 <when condition="../root-leaf != 'nonsense'"
                       context-node="parent"/>
             </choice>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_grouped_container(self, consolidated_model):
         grouped_container_elem = consolidated_model.find(
-            'yin:container[@name="grouped-container"]', namespaces=NSMAP)
+            'yin:container[@name="grouped-container"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(grouped_container_elem)
 
         expected_xml = """
@@ -624,13 +656,16 @@ class TestUses(object):
                           context-node="parent"/>
                 </anyxml>
             </container>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_grouped_leaf(self, consolidated_model):
         grouped_leaf_elem = consolidated_model.find(
-            'yin:leaf[@name="grouped-leaf"]', namespaces=NSMAP)
+            'yin:leaf[@name="grouped-leaf"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(grouped_leaf_elem)
 
         expected_xml = """
@@ -647,13 +682,16 @@ class TestUses(object):
                 <when condition="../root-leaf != 'nonsense'"
                       context-node="parent"/>
             </leaf>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_grouped_leaf_list(self, consolidated_model):
         grouped_leaf_list_elem = consolidated_model.find(
-            'yin:leaf-list[@name="grouped-leaf-list"]', namespaces=NSMAP)
+            'yin:leaf-list[@name="grouped-leaf-list"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(grouped_leaf_list_elem)
 
         expected_xml = """
@@ -663,13 +701,16 @@ class TestUses(object):
                 <when condition="../root-leaf != 'nonsense'"
                       context-node="parent"/>
             </leaf-list>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_grouped_list(self, consolidated_model):
         grouped_list_elem = consolidated_model.find(
-            'yin:list[@name="grouped-list"]', namespaces=NSMAP)
+            'yin:list[@name="grouped-list"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(grouped_list_elem)
 
         expected_xml = """
@@ -679,13 +720,16 @@ class TestUses(object):
                 <when condition="../root-leaf != 'nonsense'"
                       context-node="parent"/>
             </list>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
     def test_nested_uses(self, consolidated_model):
         nested_grouped_anyxml_elem = consolidated_model.find(
-            'yin:anyxml[@name="nested-grouped-anyxml"]', namespaces=NSMAP)
+            'yin:anyxml[@name="nested-grouped-anyxml"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(nested_grouped_anyxml_elem)
 
         expected_xml = """
@@ -696,16 +740,18 @@ class TestUses(object):
                 <when condition="grouped-leaf != 'nonsense'"
                       context-node="parent"/>
             </anyxml>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestNotification(object):
-
     def test_notification(self, consolidated_model):
         notification_elem = consolidated_model.find(
-            'yin:notification[@name="test-notification"]', namespaces=NSMAP)
+            'yin:notification[@name="test-notification"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(notification_elem)
 
         expected_xml = """
@@ -736,16 +782,18 @@ class TestNotification(object):
                     <type name="string"/>
                 </leaf>
             </notification>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestRpc(object):
-
     def test_rpc(self, consolidated_model):
         rpc_elem = consolidated_model.find(
-            'yin:rpc[@name="test-rpc"]', namespaces=NSMAP)
+            'yin:rpc[@name="test-rpc"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(rpc_elem)
 
         expected_xml = """
@@ -807,16 +855,18 @@ class TestRpc(object):
                     <anyxml name="grouped-anyxml"/>
                 </output>
             </rpc>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestTypedef(object):
-
     def test_typedefs_expanded(self, consolidated_model):
         leaf_elem = consolidated_model.find(
-            'yin:leaf[@name="leaf-with-typedef"]', namespaces=NSMAP)
+            'yin:leaf[@name="leaf-with-typedef"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(leaf_elem)
 
         expected_xml = """
@@ -843,16 +893,18 @@ class TestTypedef(object):
                     </typedef>
                 </type>
             </leaf>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestLeafref(object):
-
     def test_leafref_type_resolved(self, consolidated_model):
         leaf_elem = consolidated_model.find(
-            'yin:leaf[@name="leaf-with-leafref"]', namespaces=NSMAP)
+            'yin:leaf[@name="leaf-with-leafref"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(leaf_elem)
 
         expected_xml = """
@@ -862,18 +914,18 @@ class TestLeafref(object):
                     <type name="string"/>
                 </type>
             </leaf>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
 
 class TestAugment(object):
-
     @pytest.fixture
     def augmented_container_elem(self, consolidated_model):
         return consolidated_model.find(
-            'yin:container[@name="augmented-container"]',
-            namespaces=NSMAP
+            'yin:container[@name="augmented-container"]', namespaces=NSMAP
         )
 
     def test_number_of_children(self, augmented_container_elem):
@@ -881,26 +933,27 @@ class TestAugment(object):
 
     def test_augmenting_leaf_internal(self, augmented_container_elem):
         augmenting_leaf_internal_elem = augmented_container_elem.find(
-            'yin:leaf[@name="augmenting-leaf-internal"]', namespaces=NSMAP)
+            'yin:leaf[@name="augmenting-leaf-internal"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_leaf_internal_elem)
 
         expected_xml = """
             <leaf xmlns="{yin}" name="augmenting-leaf-internal">
                 <type name="string"/>
             </leaf>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
-        expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE
-        }
+        expected_nsmap = {"yin": YIN_NAMESPACE, "test": TEST_NAMESPACE}
         assert augmenting_leaf_internal_elem.nsmap == expected_nsmap
 
     def test_augmenting_anyxml(self, augmented_container_elem):
         augmenting_anyxml_elem = augmented_container_elem.find(
-            'yin:anyxml[@name="augmenting-anyxml"]', namespaces=NSMAP)
+            'yin:anyxml[@name="augmenting-anyxml"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_anyxml_elem)
 
         expected_xml = """
@@ -912,21 +965,24 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </anyxml>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert augmenting_anyxml_elem.nsmap == expected_nsmap
 
     def test_augmenting_choice(self, augmented_container_elem):
         augmenting_choice_elem = augmented_container_elem.find(
-            'yin:choice[@name="augmenting-choice"]', namespaces=NSMAP)
+            'yin:choice[@name="augmenting-choice"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_choice_elem)
 
         expected_xml = """
@@ -938,21 +994,24 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </choice>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert augmenting_choice_elem.nsmap == expected_nsmap
 
     def test_augmenting_container(self, augmented_container_elem):
         augmenting_container_elem = augmented_container_elem.find(
-            'yin:container[@name="augmenting-container"]', namespaces=NSMAP)
+            'yin:container[@name="augmenting-container"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_container_elem)
 
         expected_xml = """
@@ -966,21 +1025,24 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </container>
-            """.format(**NSMAP)  # nopep8
+            """.format(
+            **NSMAP
+        )  # nopep8
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert augmenting_container_elem.nsmap == expected_nsmap
 
     def test_augmenting_leaf(self, augmented_container_elem):
         augmenting_leaf_elem = augmented_container_elem.find(
-            'yin:leaf[@name="augmenting-leaf"]', namespaces=NSMAP)
+            'yin:leaf[@name="augmenting-leaf"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_leaf_elem)
 
         expected_xml = """
@@ -993,21 +1055,24 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </leaf>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert augmenting_leaf_elem.nsmap == expected_nsmap
 
     def test_augmenting_leaf_list(self, augmented_container_elem):
         augmenting_leaf_list_elem = augmented_container_elem.find(
-            'yin:leaf-list[@name="augmenting-leaf-list"]', namespaces=NSMAP)
+            'yin:leaf-list[@name="augmenting-leaf-list"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_leaf_list_elem)
 
         expected_xml = """
@@ -1020,21 +1085,24 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </leaf-list>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert augmenting_leaf_list_elem.nsmap == expected_nsmap
 
     def test_augmenting_list(self, augmented_container_elem):
         augmenting_list_elem = augmented_container_elem.find(
-            'yin:list[@name="augmenting-list"]', namespaces=NSMAP)
+            'yin:list[@name="augmenting-list"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(augmenting_list_elem)
 
         expected_xml = """
@@ -1047,21 +1115,24 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </list>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert augmenting_list_elem.nsmap == expected_nsmap
 
     def test_uses_in_augment(self, augmented_container_elem):
         grouped_anyxml_elem = augmented_container_elem.find(
-            'yin:anyxml[@name="grouped-anyxml"]', namespaces=NSMAP)
+            'yin:anyxml[@name="grouped-anyxml"]', namespaces=NSMAP
+        )
         actual_xml = etree.tostring(grouped_anyxml_elem)
 
         expected_xml = """
@@ -1073,14 +1144,16 @@ class TestAugment(object):
                 <when condition="/t:root-leaf != 'nonsense'"
                       context-node="parent"/>
             </anyxml>
-            """.format(**NSMAP)
+            """.format(
+            **NSMAP
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
         expected_nsmap = {
-            'yin': YIN_NAMESPACE,
-            'test': TEST_NAMESPACE,
-            't': TEST_NAMESPACE,
-            'aug': AUGMENTING_NAMESPACE
+            "yin": YIN_NAMESPACE,
+            "test": TEST_NAMESPACE,
+            "t": TEST_NAMESPACE,
+            "aug": AUGMENTING_NAMESPACE,
         }
         assert grouped_anyxml_elem.nsmap == expected_nsmap

--- a/test/plugin_xml_test.py
+++ b/test/plugin_xml_test.py
@@ -136,7 +136,7 @@ class TestModule(object):
             </description>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -178,7 +178,7 @@ class TestModule(object):
             </extension>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -208,7 +208,7 @@ class TestModule(object):
             <test:simple-extension-attribute-arg xmlns:test="{test}">test-value</test:simple-extension-attribute-arg>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -223,7 +223,7 @@ class TestModule(object):
             <test:simple-extension-element-arg xmlns:test="{test}">test-value</test:simple-extension-element-arg>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -267,7 +267,7 @@ class TestModule(object):
             </test:complex-extension-attribute-arg>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -288,7 +288,7 @@ class TestModule(object):
             </test:complex-extension-element-arg>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -684,7 +684,7 @@ class TestUses(object):
             </leaf>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 
@@ -1027,7 +1027,7 @@ class TestAugment(object):
             </container>
             """.format(
             **NSMAP
-        )  # nopep8
+        )
 
         assert_xml_equal(expected_xml, actual_xml)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     {py27,py34,py35,py36}-pyang{16,17,171,172,173},
-    pep8,
     pylint
 
 [testenv]
@@ -21,15 +20,6 @@ commands =
         -v {posargs} \
         test
 
-[testenv:pep8]
-deps =
-    pyang == 1.7.3
-    pytest == 3.2.3
-    pytest-pep8 == 1.0.6
-
-commands =
-    pytest --pep8 -m pep8 yinsolidated test
-
 [testenv:pylint]
 deps =
     pyang == 1.7.3
@@ -43,4 +33,4 @@ commands =
 
 [travis]
 python =
-    3.6: py36, pep8, pylint
+    3.6: py36, pylint

--- a/yinsolidated/__init__.py
+++ b/yinsolidated/__init__.py
@@ -5,5 +5,7 @@
 # pylint: disable=wildcard-import,unused-wildcard-import
 
 # Forward module definitions
+from yinsolidated._error import Error, MissingModuleNameError, MissingPrefixError
 from yinsolidated._version import __version__
+from yinsolidated.json_parser import parse as parse_json
 from yinsolidated.parser import *

--- a/yinsolidated/_common.py
+++ b/yinsolidated/_common.py
@@ -2,25 +2,14 @@
 
 """Shared constants and utilities"""
 
-YIN_NS = 'urn:ietf:params:xml:ns:yang:yin:1'
+YIN_NS = "urn:ietf:params:xml:ns:yang:yin:1"
 
 
 # [RFC 6020 Section 3]
 
-DATA_NODE_KEYWORDS = [
-    'container',
-    'leaf',
-    'leaf-list',
-    'list',
-    'anyxml'
-]
+DATA_NODE_KEYWORDS = ["container", "leaf", "leaf-list", "list", "anyxml"]
 
-DATA_DEFINITION_KEYWORDS = DATA_NODE_KEYWORDS + [
-    'choice',
-    'case',
-    'augment',
-    'uses'
-]
+DATA_DEFINITION_KEYWORDS = DATA_NODE_KEYWORDS + ["choice", "case", "augment", "uses"]
 
 
 def is_data_node(keyword):

--- a/yinsolidated/_error.py
+++ b/yinsolidated/_error.py
@@ -1,0 +1,34 @@
+# Copyright 2020 128 Technology, Inc.
+
+"""Define all the exceptions of yinsolidated."""
+
+
+class Error(Exception):
+    """Base exception for yinsolidated."""
+
+
+class _MissingAttributeError(Error):
+
+    """Could not find an attribute"""
+
+    def __init__(self, attr, data_def_element):
+        message = "No {} attribute found for ancestors of {} '{}'".format(
+            attr, data_def_element.keyword, data_def_element.name
+        )
+        super(_MissingAttributeError, self).__init__(message)
+
+
+class MissingPrefixError(_MissingAttributeError):
+
+    """Could not find prefix attribute"""
+
+    def __init__(self, data_def_element):
+        super(MissingPrefixError, self).__init__("prefix", data_def_element)
+
+
+class MissingModuleNameError(_MissingAttributeError):
+
+    """Could not find module-name attribute"""
+
+    def __init__(self, data_def_element):
+        super(MissingModuleNameError, self).__init__("module-name", data_def_element)

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = "1.4.0"
+__version__ = "2.0.0"

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = '1.4.0'
+__version__ = "1.4.0"

--- a/yinsolidated/json_parser.py
+++ b/yinsolidated/json_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2016 128 Technology, Inc.
+# Copyright 2020 128 Technology, Inc.
 
 """
 Parses the YINsolidated model into an JSON document containing custom dict subclasses

--- a/yinsolidated/parser.py
+++ b/yinsolidated/parser.py
@@ -20,11 +20,10 @@ from lxml import etree
 from yinsolidated import _common
 
 
-_NSMAP = {'yin': _common.YIN_NS}
+_NSMAP = {"yin": _common.YIN_NS}
 
-_DATA_NODE_PREDICATE = ' or '.join(
-    'self::yin:{}'.format(keyword)
-    for keyword in _common.DATA_NODE_KEYWORDS
+_DATA_NODE_PREDICATE = " or ".join(
+    "self::yin:{}".format(keyword) for keyword in _common.DATA_NODE_KEYWORDS
 )
 
 
@@ -34,29 +33,26 @@ class Error(Exception):
 
 
 class _ConsolidatedModelLookup(etree.CustomElementClassLookup):
-
     def lookup(self, _node_type, _document, namespace, name):
-        return (_get_yin_element_class(name)
-                if namespace == _common.YIN_NS
-                else None)
+        return _get_yin_element_class(name) if namespace == _common.YIN_NS else None
 
 
 def _get_yin_element_class(name):
     yin_element_class_map = {
-        'module': ModuleElement,
-        'rpc': RpcElement,
-        'container': ContainerElement,
-        'leaf': LeafElement,
-        'leaf-list': LeafListElement,
-        'list': ListElement,
-        'anyxml': AnyxmlElement,
-        'type': TypeElement,
-        'typedef': TypedefElement,
-        'bit': BitElement,
-        'enum': EnumElement,
-        'pattern': PatternElement,
-        'when': WhenElement,
-        'identity': IdentityElement
+        "module": ModuleElement,
+        "rpc": RpcElement,
+        "container": ContainerElement,
+        "leaf": LeafElement,
+        "leaf-list": LeafListElement,
+        "list": ListElement,
+        "anyxml": AnyxmlElement,
+        "type": TypeElement,
+        "typedef": TypedefElement,
+        "bit": BitElement,
+        "enum": EnumElement,
+        "pattern": PatternElement,
+        "when": WhenElement,
+        "identity": IdentityElement,
     }
 
     try:
@@ -86,7 +82,6 @@ def fromstring(xml_string):
 
 
 class YinElement(etree.ElementBase):
-
     @property
     def keyword(self):
         return etree.QName(self.tag).localname
@@ -98,8 +93,7 @@ class YinElement(etree.ElementBase):
     @property
     def module_name(self):
         ancestor_prefixes = self.xpath(
-            'ancestor-or-self::yin:*[@module-name]/@module-name',
-            namespaces=_NSMAP
+            "ancestor-or-self::yin:*[@module-name]/@module-name", namespaces=_NSMAP
         )
         try:
             return ancestor_prefixes[-1]
@@ -109,8 +103,7 @@ class YinElement(etree.ElementBase):
     @property
     def prefix(self):
         ancestor_prefixes = self.xpath(
-            'ancestor-or-self::yin:*[@module-prefix]/@module-prefix',
-            namespaces=_NSMAP
+            "ancestor-or-self::yin:*[@module-prefix]/@module-prefix", namespaces=_NSMAP
         )
         try:
             return ancestor_prefixes[-1]
@@ -127,8 +120,7 @@ class YinElement(etree.ElementBase):
 
     @property
     def description(self):
-        description = self.findtext('yin:description/yin:text',
-                                    namespaces=_NSMAP)
+        description = self.findtext("yin:description/yin:text", namespaces=_NSMAP)
 
         if description is not None:
             description = _change_all_whitespace_to_spaces(description)
@@ -142,24 +134,22 @@ class YinElement(etree.ElementBase):
 
     def iterate_rpcs(self):
         for child in self:
-            if etree.QName(child.tag).localname == 'rpc':
+            if etree.QName(child.tag).localname == "rpc":
                 yield child
 
     def get_ancestor_data_nodes(self):
         return self.xpath(
-            'ancestor::*[{}]'.format(_DATA_NODE_PREDICATE),
-            namespaces=_NSMAP
+            "ancestor::*[{}]".format(_DATA_NODE_PREDICATE), namespaces=_NSMAP
         )
 
     def get_ancestor_or_self_data_nodes(self):
         return self.xpath(
-            'ancestor-or-self::*[{}]'.format(_DATA_NODE_PREDICATE),
-            namespaces=_NSMAP
+            "ancestor-or-self::*[{}]".format(_DATA_NODE_PREDICATE), namespaces=_NSMAP
         )
 
 
 def _change_all_whitespace_to_spaces(string):
-    return re.sub(r'\s+', ' ', string).strip()
+    return re.sub(r"\s+", " ", string).strip()
 
 
 class _MissingAttributeError(Error):
@@ -168,9 +158,7 @@ class _MissingAttributeError(Error):
 
     def __init__(self, attr, data_def_element):
         message = "No {} attribute found for ancestors of {} '{}'".format(
-            attr,
-            data_def_element.keyword,
-            data_def_element.name
+            attr, data_def_element.keyword, data_def_element.name
         )
         super(_MissingAttributeError, self).__init__(message)
 
@@ -180,7 +168,7 @@ class MissingPrefixError(_MissingAttributeError):
     """Could not find prefix attribute"""
 
     def __init__(self, data_def_element):
-        super(MissingPrefixError, self).__init__('prefix', data_def_element)
+        super(MissingPrefixError, self).__init__("prefix", data_def_element)
 
 
 class MissingModuleNameError(_MissingAttributeError):
@@ -188,23 +176,19 @@ class MissingModuleNameError(_MissingAttributeError):
     """Could not find module-name attribute"""
 
     def __init__(self, data_def_element):
-        super(MissingModuleNameError, self).__init__(
-            'module-name', data_def_element
-        )
+        super(MissingModuleNameError, self).__init__("module-name", data_def_element)
 
 
 class ModuleElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
 
 class DefinitionElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
     @property
     def status(self):
@@ -212,45 +196,42 @@ class DefinitionElement(YinElement):
 
 
 class RpcElement(DefinitionElement):
-
     @property
     def input(self):
-        return self.find('yin:input', namespaces=_NSMAP)
+        return self.find("yin:input", namespaces=_NSMAP)
 
     @property
     def output(self):
-        return self.find('yin:output', namespaces=_NSMAP)
+        return self.find("yin:output", namespaces=_NSMAP)
 
 
 class DataDefinitionElement(DefinitionElement):
-
     @property
     def is_config(self):
         return self.xpath(
             'count(ancestor-or-self::yin:*[yin:config/@value = "false"]) = 0',
-            namespaces=_NSMAP)
+            namespaces=_NSMAP,
+        )
 
     @property
     def when_elements(self):
-        return self.findall('yin:when', namespaces=_NSMAP)
+        return self.findall("yin:when", namespaces=_NSMAP)
 
 
 class ContainerElement(DataDefinitionElement):
-
     @property
     def presence(self):
-        return _get_subelem_attribute_or_default(self, 'presence', 'value')
+        return _get_subelem_attribute_or_default(self, "presence", "value")
 
 
-def _get_subelem_attribute_or_default(data_def_element, subelem_name,
-                                      attr_name, default=None):
-    element = data_def_element.find('yin:{}'.format(subelem_name),
-                                    namespaces=_NSMAP)
+def _get_subelem_attribute_or_default(
+    data_def_element, subelem_name, attr_name, default=None
+):
+    element = data_def_element.find("yin:{}".format(subelem_name), namespaces=_NSMAP)
     return element.get(attr_name) if element is not None else default
 
 
 class LeafElement(DataDefinitionElement):
-
     @property
     def type(self):
         return _get_type(self)
@@ -269,36 +250,39 @@ class LeafElement(DataDefinitionElement):
 
     @property
     def is_list_key(self):
-        return ((self.getparent() is not None) and
-                (self.getparent().keyword == 'list') and
-                ((self.name, self.namespace) in self.getparent().key_ids))
+        return (
+            (self.getparent() is not None)
+            and (self.getparent().keyword == "list")
+            and ((self.name, self.namespace) in self.getparent().key_ids)
+        )
 
 
 def _get_type(element):
-    return element.find('yin:type', namespaces=_NSMAP)
+    return element.find("yin:type", namespaces=_NSMAP)
 
 
 def _get_status(element):
     return _get_subelem_attribute_or_default(
-        element, 'status', 'value', default='current')
+        element, "status", "value", default="current"
+    )
 
 
 def _get_default(element):
-    return _get_subelem_attribute_or_default(element, 'default', 'value')
+    return _get_subelem_attribute_or_default(element, "default", "value")
 
 
 def _get_units(element):
-    return _get_subelem_attribute_or_default(element, 'units', 'name')
+    return _get_subelem_attribute_or_default(element, "units", "name")
 
 
 def _is_mandatory(element):
     mandatory_string = _get_subelem_attribute_or_default(
-        element, 'mandatory', 'value', default='false')
-    return mandatory_string == 'true'
+        element, "mandatory", "value", default="false"
+    )
+    return mandatory_string == "true"
 
 
 class LeafListElement(DataDefinitionElement):
-
     @property
     def type(self):
         return _get_type(self)
@@ -322,32 +306,33 @@ class LeafListElement(DataDefinitionElement):
 
 def _get_min_elements(data_def_element):
     min_elements_string = _get_subelem_attribute_or_default(
-        data_def_element, 'min-elements', 'value', default='0')
+        data_def_element, "min-elements", "value", default="0"
+    )
     return int(min_elements_string)
 
 
 def _get_max_elements(data_def_element):
     max_elements_string = _get_subelem_attribute_or_default(
-        data_def_element, 'max-elements', 'value', default='unbounded')
-    return (None if max_elements_string == 'unbounded'
-            else int(max_elements_string))
+        data_def_element, "max-elements", "value", default="unbounded"
+    )
+    return None if max_elements_string == "unbounded" else int(max_elements_string)
 
 
 def _get_ordered_by(data_def_element):
     return _get_subelem_attribute_or_default(
-        data_def_element, 'ordered-by', 'value', default='system')
+        data_def_element, "ordered-by", "value", default="system"
+    )
 
 
 class ListElement(DataDefinitionElement):
-
     @property
     def key_ids(self):
         keys = []
 
-        key_string = self.xpath('string(yin:key/@value)', namespaces=_NSMAP)
+        key_string = self.xpath("string(yin:key/@value)", namespaces=_NSMAP)
         for key_identifier in key_string.split():
-            if ':' in key_identifier:
-                prefix, name = key_identifier.split(':')
+            if ":" in key_identifier:
+                prefix, name = key_identifier.split(":")
                 namespace = self.nsmap[prefix]
             else:
                 name = key_identifier
@@ -359,8 +344,7 @@ class ListElement(DataDefinitionElement):
 
     @property
     def unique(self):
-        unique_str = _get_subelem_attribute_or_default(
-            self, 'unique', 'tag', '')
+        unique_str = _get_subelem_attribute_or_default(self, "unique", "tag", "")
         return unique_str.split()
 
     @property
@@ -377,26 +361,24 @@ class ListElement(DataDefinitionElement):
 
 
 class AnyxmlElement(DataDefinitionElement):
-
     @property
     def is_mandatory(self):
         return _is_mandatory(self)
 
 
 class TypeElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
     @property
     def unprefixed_name(self):
-        return self.name.split(':')[-1]
+        return self.name.split(":")[-1]
 
     @property
     def prefix(self):
-        if ':' in self.name:
-            return self.name.split(':')[0]
+        if ":" in self.name:
+            return self.name.split(":")[0]
 
         return super(TypeElement, self).prefix
 
@@ -407,26 +389,25 @@ class TypeElement(YinElement):
 
     @property
     def typedef(self):
-        return self.find('yin:typedef', namespaces=_NSMAP)
+        return self.find("yin:typedef", namespaces=_NSMAP)
 
     @property
     def bits(self):
-        return self.base_type.findall('yin:bit', namespaces=_NSMAP)
+        return self.base_type.findall("yin:bit", namespaces=_NSMAP)
 
     @property
     def enums(self):
-        return self.base_type.findall('yin:enum', namespaces=_NSMAP)
+        return self.base_type.findall("yin:enum", namespaces=_NSMAP)
 
     @property
     def fraction_digits(self):
         return _get_subelem_attribute_or_default(
-            self.base_type, 'fraction-digits', 'value')
+            self.base_type, "fraction-digits", "value"
+        )
 
     @property
     def length(self):
-        range_value = _get_subelem_attribute_or_default(
-            self, 'length', 'value'
-        )
+        range_value = _get_subelem_attribute_or_default(self, "length", "value")
 
         if range_value is None and self.typedef is not None:
             range_value = self.typedef.type.length
@@ -435,18 +416,15 @@ class TypeElement(YinElement):
 
     @property
     def path(self):
-        return _get_subelem_attribute_or_default(
-            self.base_type, 'path', 'value')
+        return _get_subelem_attribute_or_default(self.base_type, "path", "value")
 
     @property
     def patterns(self):
-        return self.base_type.findall('yin:pattern', namespaces=_NSMAP)
+        return self.base_type.findall("yin:pattern", namespaces=_NSMAP)
 
     @property
     def range(self):
-        range_value = _get_subelem_attribute_or_default(
-            self, 'range', 'value'
-        )
+        range_value = _get_subelem_attribute_or_default(self, "range", "value")
 
         if range_value is None and self.typedef is not None:
             range_value = self.typedef.type.range
@@ -456,19 +434,24 @@ class TypeElement(YinElement):
     @property
     def referenced_type(self):
         base_type_elem = self.base_type
-        return (base_type_elem.find('yin:type', namespaces=_NSMAP)
-                if base_type_elem.name == 'leafref' else None)
+        return (
+            base_type_elem.find("yin:type", namespaces=_NSMAP)
+            if base_type_elem.name == "leafref"
+            else None
+        )
 
     @property
     def subtypes(self):
         base_type_elem = self.base_type
-        return (base_type_elem.findall('yin:type', namespaces=_NSMAP)
-                if base_type_elem.name == 'union' else [])
+        return (
+            base_type_elem.findall("yin:type", namespaces=_NSMAP)
+            if base_type_elem.name == "union"
+            else []
+        )
 
     @property
     def base_identity(self):
-        return _get_subelem_attribute_or_default(
-            self.base_type, 'base', 'name')
+        return _get_subelem_attribute_or_default(self.base_type, "base", "name")
 
     def get_identities(self):
         return list(self.iterate_identities())
@@ -487,9 +470,10 @@ class TypeElement(YinElement):
         data_node = self.getparent()
 
         identifier_to_find = _parse_identifier(
-            identity, data_node.namespace_map, data_node.namespace)
+            identity, data_node.namespace_map, data_node.namespace
+        )
 
-        for identity_elem in root.iterfind('yin:identity', namespaces=_NSMAP):
+        for identity_elem in root.iterfind("yin:identity", namespaces=_NSMAP):
             identifier = (identity_elem.name, identity_elem.namespace)
             if identifier == identifier_to_find:
                 return identity_elem
@@ -498,8 +482,8 @@ class TypeElement(YinElement):
 
 
 def _parse_identifier(identifier, nsmap, default_namespace):
-    if ':' in identifier:
-        prefix, name = identifier.split(':')
+    if ":" in identifier:
+        prefix, name = identifier.split(":")
         namespace = nsmap[prefix]
     else:
         name = identifier
@@ -509,18 +493,16 @@ def _parse_identifier(identifier, nsmap, default_namespace):
 
 
 class MissingIdentityError(Error):
-
     def __init__(self, name, namespace):
         super(MissingIdentityError, self).__init__(
-            'Could not find identity {} in namespace {}'.format(
-                name, namespace))
+            "Could not find identity {} in namespace {}".format(name, namespace)
+        )
 
 
 class TypedefElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
     @property
     def type(self):
@@ -536,55 +518,51 @@ class TypedefElement(YinElement):
 
 
 class BitElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
     @property
     def position(self):
-        position = _get_subelem_attribute_or_default(self, 'position', 'value')
+        position = _get_subelem_attribute_or_default(self, "position", "value")
         return int(position) if position is not None else None
 
 
 class EnumElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
     @property
     def value(self):
-        value = _get_subelem_attribute_or_default(self, 'value', 'value')
+        value = _get_subelem_attribute_or_default(self, "value", "value")
         return int(value) if value is not None else None
 
 
 class PatternElement(YinElement):
-
     @property
     def value(self):
-        return self.get('value')
+        return self.get("value")
 
     @property
     def error_message(self):
-        return self.findtext('yin:error-message/yin:value', namespaces=_NSMAP)
+        return self.findtext("yin:error-message/yin:value", namespaces=_NSMAP)
 
 
 class WhenElement(YinElement):
-
     @property
     def condition(self):
         data_def_element = self.getparent()
-        assert hasattr(data_def_element, 'prefix'), (
-            "Parent of 'when' element is not a data definition element"
-        )
+        assert hasattr(
+            data_def_element, "prefix"
+        ), "Parent of 'when' element is not a data definition element"
 
         prefix = data_def_element.prefix
-        return _ensure_xpath_names_prefixed(self.get('condition'), prefix)
+        return _ensure_xpath_names_prefixed(self.get("condition"), prefix)
 
     @property
     def context_node_is_parent(self):
-        return self.get('context-node') == 'parent'
+        return self.get("context-node") == "parent"
 
 
 def _ensure_xpath_names_prefixed(expression, prefix):
@@ -592,30 +570,30 @@ def _ensure_xpath_names_prefixed(expression, prefix):
     new_tokens = []
 
     for token_type, token in tokens:
-        if token_type == 'name' and ':' not in token:
-            new_tokens.append('{}:{}'.format(prefix, token))
+        if token_type == "name" and ":" not in token:
+            new_tokens.append("{}:{}".format(prefix, token))
         else:
             new_tokens.append(token)
 
-    return ''.join(new_tokens)
+    return "".join(new_tokens)
 
 
 class IdentityElement(YinElement):
-
     @property
     def name(self):
-        return self.get('name')
+        return self.get("name")
 
     @property
     def base(self):
-        base = _get_subelem_attribute_or_default(self, 'base', 'name')
+        base = _get_subelem_attribute_or_default(self, "base", "name")
 
         if base is None:
             name = None
             namespace = None
         else:
             name, namespace = _parse_identifier(
-                base, self.namespace_map, self.namespace)
+                base, self.namespace_map, self.namespace
+            )
 
         return name, namespace
 
@@ -633,6 +611,6 @@ class IdentityElement(YinElement):
 
     def iterate_directly_derived_identities(self):
         root = self.getroottree()
-        for identity_elem in root.iterfind('yin:identity', namespaces=_NSMAP):
+        for identity_elem in root.iterfind("yin:identity", namespaces=_NSMAP):
             if identity_elem.base == (self.name, self.namespace):
                 yield identity_elem


### PR DESCRIPTION
Add a new flag to the yinsolidated Pyang plugin,
`--yinsolidated-output-format` which can be one of `xml` or `json`, with
`xml` as the default.

Add a new module `json_parser` and export a new method from the core
`yinsolidated` namespace `parse_json`, which parses the output of the
JSON version of the consolidated model and returns a (mostly) API
compatible tree of `YinElement`s.

One big gotcha is that `yinsolidated.YinElement` is a **separate** class
from `yinsolidated.json_parser.YinElement`.
`yinsolidated.YinElement` is re-exported from the `yinsolidated.parser`
module and inherits from `etree.Element`, while
`yinsolidated.json_parser.YinElement` inherits from `dict`.

The errors don't suffer from the same problem so they've been moved to
a common module and shared between the two implementations.

All the new tests are ports from the XML versions. Very few assertions
were changed, just the model literals. There are two big differences:

- No tests for RPC related code. We've stopped using this functionality
  so while it _may_ continue to work it's no longer tested, or
  documented and should be considered unsupported.

- Before `plugin_test` (now named `plugin_xml_test`) had about 1500
  lines of test literals which amounted to testing 90% of the
  consolidated model, with a lot of overlapping test coverage. Rather
  than manually copy-pasting snippets of the consolidated model I just
  ran the test, generated the actual model and am comparing against one
  big test literal.

  I also added a (disabled) test case which can be enabled to
  automatically regenerate the expected model making the test
  practically a snapshot test.

  This has the benefit of ease of updating, but the downside that we're
  now testing _everything_ about the output, so even a non-breaking
  change to the code could force the entire model to be slightly
  different. But I guess this could also be seen as a plus? 100%
  coverage baby!!