### PR TITLE
Find namespace through recursive search of parents

### DIFF
--- a/test/expected.json
+++ b/test/expected.json
@@ -12,65 +12,41 @@
     {
       "keyword": "yang-version",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "value": "1"
     },
     {
       "keyword": "namespace",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "uri": "urn:xml:ns:test"
     },
     {
       "keyword": "prefix",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "value": "test"
     },
     {
       "keyword": "organization",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "text": "None"
     },
     {
       "keyword": "contact",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "text": "Somebody"
     },
     {
       "keyword": "description",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "text": "Test module containing an exhaustive set of possible YANG statements"
     },
     {
       "keyword": "revision",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "date": "2016-04-22",
       "children": [
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "Initial revision"
         }
       ]
@@ -78,17 +54,11 @@
     {
       "keyword": "extension",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "simple-extension-no-arg",
       "children": [
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An extension that takes no argument and does not support substatements"
         }
       ]
@@ -104,25 +74,16 @@
     {
       "keyword": "extension",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "simple-extension-attribute-arg",
       "children": [
         {
           "keyword": "argument",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "attribute-argument"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An extension whose argument would appear as an XML attribute in YIN but appears simply as text in YINsolidated and does not support substatements"
         }
       ]
@@ -138,25 +99,16 @@
     {
       "keyword": "extension",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "simple-extension-element-arg",
       "children": [
         {
           "keyword": "argument",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "element-argument",
           "children": [
             {
               "keyword": "yin-element",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "true"
             }
           ]
@@ -164,25 +116,16 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An extension whose argument would appear as an XML subelement in YIN but appears simply as text in YINsolidated and does not support substatements"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         }
       ]
@@ -198,17 +141,11 @@
     {
       "keyword": "extension",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "complex-extension-no-arg",
       "children": [
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An extension that takes no argument but supports substatements because the #yinformat tag is included"
         }
       ]
@@ -223,9 +160,6 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "This will appear in YINsolidated"
         },
         {
@@ -241,25 +175,16 @@
     {
       "keyword": "extension",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "complex-extension-attribute-arg",
       "children": [
         {
           "keyword": "argument",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "attribute-argument"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An extension whose argument appears as an XML attribute in YINsolidated and supports substatements because the #yinformat tag is included"
         }
       ]
@@ -275,9 +200,6 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "This will appear in YINsolidated"
         },
         {
@@ -293,25 +215,16 @@
     {
       "keyword": "extension",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "complex-extension-element-arg",
       "children": [
         {
           "keyword": "argument",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "element-argument",
           "children": [
             {
               "keyword": "yin-element",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "true"
             }
           ]
@@ -319,9 +232,6 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An extension whose argument appears as an XML subelement in YINsolidated and supports substatements because the #yinformat tag is included"
         }
       ]
@@ -337,9 +247,6 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "This will appear in YINsolidated"
         },
         {
@@ -355,17 +262,11 @@
     {
       "keyword": "feature",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "test-feature",
       "children": [
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A test feature"
         }
       ]
@@ -374,7 +275,6 @@
       "keyword": "identity",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
       "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1",
         "test": "urn:xml:ns:test"
       },
       "name": "test-base-identity",
@@ -384,25 +284,16 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A base identity"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         }
       ]
@@ -411,7 +302,6 @@
       "keyword": "identity",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
       "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1",
         "test": "urn:xml:ns:test"
       },
       "name": "test-derived-identity",
@@ -421,9 +311,6 @@
         {
           "keyword": "base",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-base-identity"
         }
       ]
@@ -431,81 +318,51 @@
     {
       "keyword": "container",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "submodule-container"
     },
     {
       "keyword": "anyxml",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "root-anyxml",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "false"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "An anyxml node at the model root"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "mandatory",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "true"
         },
         {
           "keyword": "must",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "deprecated"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         }
       ]
@@ -513,89 +370,56 @@
     {
       "keyword": "choice",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "root-choice",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "true"
         },
         {
           "keyword": "default",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "test-case"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A choice at the model root"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "mandatory",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "false"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "obsolete"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         },
         {
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "anyxml-case",
           "children": [
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "anyxml-case"
             }
           ]
@@ -603,89 +427,56 @@
         {
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-case",
           "children": [
             {
               "keyword": "description",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "text": "A test case"
             },
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "test-feature"
             },
             {
               "keyword": "reference",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "text": "RFC 6020"
             },
             {
               "keyword": "status",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "current"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "../root-leaf != 'nonsense'"
             },
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "anyxml-within-case"
             },
             {
               "keyword": "choice",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "choice-within-case"
             },
             {
               "keyword": "container",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "container-within-case"
             },
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "leaf-within-case",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -693,17 +484,11 @@
             {
               "keyword": "leaf-list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "leaf-list-within-case",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -711,17 +496,11 @@
             {
               "keyword": "list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "list-within-case",
               "children": [
                 {
                   "keyword": "config",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "value": "false"
                 }
               ]
@@ -729,9 +508,6 @@
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "grouped-anyxml"
             }
           ]
@@ -739,17 +515,11 @@
         {
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "container-case",
           "children": [
             {
               "keyword": "container",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "container-case"
             }
           ]
@@ -757,25 +527,16 @@
         {
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "leaf-case",
           "children": [
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "leaf-case",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -785,25 +546,16 @@
         {
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "leaf-list-case",
           "children": [
             {
               "keyword": "leaf-list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "leaf-list-case",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -813,25 +565,16 @@
         {
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "list-case",
           "children": [
             {
               "keyword": "list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "list-case",
               "children": [
                 {
                   "keyword": "config",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "value": "false"
                 }
               ]
@@ -842,7 +585,6 @@
           "keyword": "case",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -853,17 +595,11 @@
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "augmenting-case-leaf",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -875,49 +611,31 @@
     {
       "keyword": "container",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "root-container",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "true"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A container at the model root"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "must",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "test-leaf != 'nonsense'",
           "children": [
             {
               "keyword": "error-message",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "test-leaf is nonsense"
             }
           ]
@@ -925,89 +643,56 @@
         {
           "keyword": "presence",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "This container has presence"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         },
         {
           "keyword": "anyxml",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-anyxml"
         },
         {
           "keyword": "choice",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-choice"
         },
         {
           "keyword": "container",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-nested-container"
         },
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-leaf",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "inner-type",
               "children": [
                 {
                   "keyword": "typedef",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "inner-type",
                   "children": [
                     {
                       "keyword": "type",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "string"
                     }
                   ]
@@ -1019,17 +704,11 @@
         {
           "keyword": "leaf-list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-leaf-list",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -1037,17 +716,11 @@
         {
           "keyword": "list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-list",
           "children": [
             {
               "keyword": "config",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "false"
             }
           ]
@@ -1055,17 +728,11 @@
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "grouped-leaf",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -1075,97 +742,61 @@
     {
       "keyword": "leaf",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "root-leaf",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "true"
         },
         {
           "keyword": "default",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "test-default"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A leaf at the model root"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "mandatory",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "false"
         },
         {
           "keyword": "must",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "count(../root-leaf-list) > 0"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         },
         {
           "keyword": "type",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "string"
         },
         {
           "keyword": "units",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "goobers"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "count(../root-leaf-list) > 0"
         }
       ]
@@ -1173,105 +804,66 @@
     {
       "keyword": "leaf-list",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "root-leaf-list",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "true"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A leaf-list at the model root"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "max-elements",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "10"
         },
         {
           "keyword": "min-elements",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "1"
         },
         {
           "keyword": "must",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         },
         {
           "keyword": "ordered-by",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "user"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         },
         {
           "keyword": "type",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "string"
         },
         {
           "keyword": "units",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "awesomeness"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         }
       ]
@@ -1279,161 +871,101 @@
     {
       "keyword": "list",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "root-list",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "true"
         },
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A list at the model root"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "key",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "test-key"
         },
         {
           "keyword": "max-elements",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "100"
         },
         {
           "keyword": "min-elements",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "50"
         },
         {
           "keyword": "must",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         },
         {
           "keyword": "ordered-by",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "system"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         },
         {
           "keyword": "unique",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "tag": "grouped-leaf"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'"
         },
         {
           "keyword": "anyxml",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-anyxml"
         },
         {
           "keyword": "choice",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-choice"
         },
         {
           "keyword": "container",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-container"
         },
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-key",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "inner-type",
               "children": [
                 {
                   "keyword": "typedef",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "inner-type",
                   "children": [
                     {
                       "keyword": "type",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "string"
                     }
                   ]
@@ -1445,17 +977,11 @@
         {
           "keyword": "leaf-list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-leaf-list",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -1463,17 +989,11 @@
         {
           "keyword": "list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-nested-list",
           "children": [
             {
               "keyword": "config",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "false"
             }
           ]
@@ -1481,17 +1001,11 @@
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "grouped-leaf",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -1501,25 +1015,16 @@
     {
       "keyword": "choice",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "grouped-choice",
       "children": [
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'",
           "context-node": "parent"
         }
@@ -1528,42 +1033,27 @@
     {
       "keyword": "container",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "grouped-container",
       "children": [
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'",
           "context-node": "parent"
         },
         {
           "keyword": "anyxml",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "augmented-in-uses-anyxml",
           "children": [
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "../grouped-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -1574,33 +1064,21 @@
     {
       "keyword": "leaf",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "grouped-leaf",
       "children": [
         {
           "keyword": "type",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "grouped-typedef",
           "children": [
             {
               "keyword": "typedef",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "grouped-typedef",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -1610,25 +1088,16 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A leaf in a grouping with a refined description"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'",
           "context-node": "parent"
         }
@@ -1637,33 +1106,21 @@
     {
       "keyword": "leaf-list",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "grouped-leaf-list",
       "children": [
         {
           "keyword": "type",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "string"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'",
           "context-node": "parent"
         }
@@ -1672,33 +1129,21 @@
     {
       "keyword": "list",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "grouped-list",
       "children": [
         {
           "keyword": "config",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "false"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'",
           "context-node": "parent"
         }
@@ -1707,34 +1152,22 @@
     {
       "keyword": "anyxml",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "nested-grouped-anyxml",
       "children": [
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "../root-leaf != 'nonsense'",
           "context-node": "parent"
         },
         {
           "keyword": "when",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "condition": "grouped-leaf != 'nonsense'",
           "context-node": "parent"
         }
@@ -1743,97 +1176,61 @@
     {
       "keyword": "leaf",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "leaf-with-typedef",
       "children": [
         {
           "keyword": "type",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "derived-typedef",
           "children": [
             {
               "keyword": "typedef",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "derived-typedef",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "base-typedef",
                   "children": [
                     {
                       "keyword": "length",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "value": "11 | 42..max"
                     },
                     {
                       "keyword": "typedef",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "base-typedef",
                       "children": [
                         {
                           "keyword": "default",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "value": "bumfuzzling"
                         },
                         {
                           "keyword": "description",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "text": "A base typedef"
                         },
                         {
                           "keyword": "reference",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "text": "RFC 6020"
                         },
                         {
                           "keyword": "status",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "value": "current"
                         },
                         {
                           "keyword": "type",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "name": "string",
                           "children": [
                             {
                               "keyword": "length",
                               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                              "nsmap": {
-                                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                              },
                               "value": "1..255"
                             }
                           ]
@@ -1841,9 +1238,6 @@
                         {
                           "keyword": "units",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "name": "nonsense"
                         }
                       ]
@@ -1859,33 +1253,21 @@
     {
       "keyword": "leaf",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "leaf-with-leafref",
       "children": [
         {
           "keyword": "type",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "leafref",
           "children": [
             {
               "keyword": "path",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "../root-leaf"
             },
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -1895,25 +1277,16 @@
     {
       "keyword": "container",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "augmented-container",
       "children": [
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "augmenting-leaf-internal",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -1922,7 +1295,6 @@
           "keyword": "anyxml",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -1933,17 +1305,11 @@
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -1953,7 +1319,6 @@
           "keyword": "choice",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -1964,17 +1329,11 @@
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -1984,7 +1343,6 @@
           "keyword": "container",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -2003,17 +1361,11 @@
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -2023,7 +1375,6 @@
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -2034,25 +1385,16 @@
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             },
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -2062,7 +1404,6 @@
           "keyword": "leaf-list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -2073,25 +1414,16 @@
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             },
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -2101,7 +1433,6 @@
           "keyword": "list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -2112,25 +1443,16 @@
             {
               "keyword": "config",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "value": "false"
             },
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -2140,7 +1462,6 @@
           "keyword": "anyxml",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
           "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
             "aug": "urn:xml:ns:test:augment",
             "t": "urn:xml:ns:test"
           },
@@ -2151,17 +1472,11 @@
             {
               "keyword": "if-feature",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "t:test-feature"
             },
             {
               "keyword": "when",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "condition": "/t:root-leaf != 'nonsense'",
               "context-node": "parent"
             }
@@ -2172,97 +1487,61 @@
     {
       "keyword": "notification",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "test-notification",
       "children": [
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A test notification"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         },
         {
           "keyword": "anyxml",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "notification-anyxml"
         },
         {
           "keyword": "choice",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "notification-choice"
         },
         {
           "keyword": "container",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "notification-container"
         },
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "notification-leaf",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "inner-type",
               "children": [
                 {
                   "keyword": "typedef",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "inner-type",
                   "children": [
                     {
                       "keyword": "type",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "string"
                     }
                   ]
@@ -2274,17 +1553,11 @@
         {
           "keyword": "leaf-list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "notification-leaf-list",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -2292,25 +1565,16 @@
         {
           "keyword": "list",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "notification-list"
         },
         {
           "keyword": "leaf",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "grouped-leaf",
           "children": [
             {
               "keyword": "type",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "string"
             }
           ]
@@ -2320,104 +1584,65 @@
     {
       "keyword": "rpc",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-      "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-      },
       "name": "test-rpc",
       "children": [
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A test RPC"
         },
         {
           "keyword": "if-feature",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "test-feature"
         },
         {
           "keyword": "reference",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "RFC 6020"
         },
         {
           "keyword": "status",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "value": "current"
         },
         {
           "keyword": "input",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "children": [
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "input-anyxml"
             },
             {
               "keyword": "choice",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "input-choice"
             },
             {
               "keyword": "container",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "input-container"
             },
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "input-leaf",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "input-type",
                   "children": [
                     {
                       "keyword": "typedef",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "input-type",
                       "children": [
                         {
                           "keyword": "type",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "name": "string"
                         }
                       ]
@@ -2429,33 +1654,21 @@
             {
               "keyword": "leaf-list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "input-leaf-list",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "inner-type",
                   "children": [
                     {
                       "keyword": "typedef",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "inner-type",
                       "children": [
                         {
                           "keyword": "type",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "name": "string"
                         }
                       ]
@@ -2467,25 +1680,16 @@
             {
               "keyword": "list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "input-list"
             },
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "grouped-leaf",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -2493,9 +1697,6 @@
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "grouped-anyxml"
             }
           ]
@@ -2503,64 +1704,40 @@
         {
           "keyword": "output",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "children": [
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "output-anyxml"
             },
             {
               "keyword": "choice",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "output-choice"
             },
             {
               "keyword": "container",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "output-container"
             },
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "output-leaf",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "output-type",
                   "children": [
                     {
                       "keyword": "typedef",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "output-type",
                       "children": [
                         {
                           "keyword": "type",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "name": "string"
                         }
                       ]
@@ -2572,33 +1749,21 @@
             {
               "keyword": "leaf-list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "output-leaf-list",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "inner-type",
                   "children": [
                     {
                       "keyword": "typedef",
                       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                      "nsmap": {
-                        "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                      },
                       "name": "inner-type",
                       "children": [
                         {
                           "keyword": "type",
                           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                          "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                          },
                           "name": "string"
                         }
                       ]
@@ -2610,25 +1775,16 @@
             {
               "keyword": "list",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "output-list"
             },
             {
               "keyword": "leaf",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "grouped-leaf",
               "children": [
                 {
                   "keyword": "type",
                   "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-                  "nsmap": {
-                    "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-                  },
                   "name": "string"
                 }
               ]
@@ -2636,9 +1792,6 @@
             {
               "keyword": "anyxml",
               "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-              "nsmap": {
-                "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-              },
               "name": "grouped-anyxml"
             }
           ]
@@ -2649,7 +1802,6 @@
       "keyword": "identity",
       "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
       "nsmap": {
-        "yin": "urn:ietf:params:xml:ns:yang:yin:1",
         "aug": "urn:xml:ns:test:augment",
         "t": "urn:xml:ns:test"
       },
@@ -2660,17 +1812,11 @@
         {
           "keyword": "description",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "text": "A derived identity in an augmenting module"
         },
         {
           "keyword": "base",
           "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
-          "nsmap": {
-            "yin": "urn:ietf:params:xml:ns:yang:yin:1"
-          },
           "name": "t:test-base-identity"
         }
       ]

--- a/test/json_parser_test.py
+++ b/test/json_parser_test.py
@@ -44,7 +44,7 @@ class TestYinElement(object):
                     {
                         "keyword": "test-container",
                         "module-prefix": "in",
-                        "nsmap": {"in": "inner:ns",},
+                        "nsmap": {"in": "inner:ns"},
                         "children": [{"keyword": "choice"}],
                     }
                 ],
@@ -59,6 +59,7 @@ class TestYinElement(object):
             {
                 "keyword": "module",
                 "module-name": "test-module",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [{"keyword": "choice"}],
             }
         )
@@ -71,6 +72,7 @@ class TestYinElement(object):
             {
                 "keyword": "module",
                 "module-name": "test-module",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [
                     {
                         "keyword": "container",
@@ -88,6 +90,7 @@ class TestYinElement(object):
         module_elem = yinsolidated.parse_json(
             {
                 "keyword": "module",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [{"keyword": "container", "name": "test"}],
             }
         )
@@ -104,6 +107,7 @@ class TestYinElement(object):
             {
                 "keyword": "module",
                 "module-prefix": "test",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [{"keyword": "choice"}],
             }
         )
@@ -116,6 +120,7 @@ class TestYinElement(object):
             {
                 "keyword": "module",
                 "module-prefix": "outer",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [
                     {
                         "keyword": "container",
@@ -133,6 +138,7 @@ class TestYinElement(object):
         module_elem = yinsolidated.parse_json(
             {
                 "keyword": "module",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [{"keyword": "container", "name": "test"}],
             }
         )
@@ -148,6 +154,7 @@ class TestYinElement(object):
         module_elem = yinsolidated.parse_json(
             {
                 "keyword": "module",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [{"keyword": "description", "text": "short description"}],
             }
         )
@@ -163,6 +170,7 @@ class TestYinElement(object):
         module_elem = yinsolidated.parse_json(
             {
                 "keyword": "module",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1"},
                 "children": [
                     {"keyword": "container"},
                     {"keyword": "list"},
@@ -185,27 +193,30 @@ def ancestor_data_node_model():
     return yinsolidated.parse_json(
         {
             "keyword": "module",
-            "module-prefix": "t",
-            "nsmap": {"t": "test:ns"},
             "children": [
                 {
                     "keyword": "container",
+                    "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                     "name": "test-container",
                     "children": [
                         {
                             "keyword": "list",
+                            "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                             "name": "test-list",
                             "children": [
                                 {
                                     "keyword": "choice",
+                                    "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                     "name": "test-choice",
                                     "children": [
                                         {
                                             "keyword": "case",
+                                            "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                             "name": "case-0",
                                             "children": [
                                                 {
                                                     "keyword": "leaf",
+                                                    "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                     "children": [
                                                         {
                                                             "keyword": "type",
@@ -218,20 +229,23 @@ def ancestor_data_node_model():
                                         {
                                             "keyword": "case",
                                             "name": "case-1",
+                                            "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                             "children": [
                                                 {
                                                     "keyword": "leaf-list",
+                                                    "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                     "children": [
                                                         {
                                                             "keyword": "type",
                                                             "name": "string",
                                                         },
-                                                        {
-                                                            "keyword": "container",
-                                                            "name": "nested-container",
-                                                        },
                                                     ],
-                                                }
+                                                },
+                                                {
+                                                    "keyword": "container",
+                                                    "name": "nested-container",
+                                                    "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                                },
                                             ],
                                         },
                                     ],
@@ -240,12 +254,15 @@ def ancestor_data_node_model():
                         }
                     ],
                 },
-                {"keyword": "list", "name": "sibling-list",},
+                {
+                    "keyword": "list",
+                    "name": "sibling-list",
+                    "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                },
                 {
                     "keyword": "container",
-                    "module-prefix": "o",
-                    "nsmap": {"o": "other:ns"},
                     "name": "sibling-container",
+                    "namespace": "not:yin:ns",
                 },
             ],
         }
@@ -297,7 +314,9 @@ class TestFind(object):
 
     def test_find_with_namespace(self, ancestor_data_node_model):
         assert (
-            ancestor_data_node_model.find("container", namespace="test:ns").name
+            ancestor_data_node_model.find(
+                "container", namespace="urn:ietf:params:xml:ns:yang:yin:1"
+            ).name
             == "test-container"
         )
 
@@ -308,33 +327,20 @@ class TestFind(object):
         "keyword, namespace, recursive, expected_count",
         [
             pytest.param("container", None, False, 2, id="without_namespace"),
-            pytest.param("container", "other:ns", False, 1, id="with_namespace"),
-            pytest.param("container", None, True, 3, id="recursive_without_namespac"),
             pytest.param(
-                "container", "test:ns", True, 2, id="recursive_with_namespace"
+                "container",
+                "urn:ietf:params:xml:ns:yang:yin:1",
+                False,
+                1,
+                id="with_namespace",
             ),
-            pytest.param("leaf", None, False, 0, id="missing"),
-            pytest.param("bad", None, True, 0, id="recursive_missing"),
-        ],
-    )
-    def test_iterfind(
-        self, ancestor_data_node_model, keyword, namespace, recursive, expected_count
-    ):
-        results = ancestor_data_node_model.iterfind(
-            keyword, namespace=namespace, recursive=recursive
-        )
-
-        assert isinstance(results, types.GeneratorType)
-        assert len(list(results)) == expected_count
-
-    @pytest.mark.parametrize(
-        "keyword, namespace, recursive, expected_count",
-        [
-            pytest.param("container", None, False, 2, id="without_namespace"),
-            pytest.param("container", "other:ns", False, 1, id="with_namespace"),
             pytest.param("container", None, True, 3, id="recursive_without_namespac"),
             pytest.param(
-                "container", "test:ns", True, 2, id="recursive_with_namespace"
+                "container",
+                "urn:ietf:params:xml:ns:yang:yin:1",
+                True,
+                2,
+                id="recursive_with_namespace",
             ),
             pytest.param("leaf", None, False, 0, id="missing"),
             pytest.param("bad", None, True, 0, id="recursive_missing"),
@@ -343,6 +349,13 @@ class TestFind(object):
     def test_findall(
         self, ancestor_data_node_model, keyword, namespace, recursive, expected_count
     ):
+        iter_results = ancestor_data_node_model.iterfind(
+            keyword, namespace=namespace, recursive=recursive
+        )
+
+        assert isinstance(iter_results, types.GeneratorType)
+        assert len(list(iter_results)) == expected_count
+
         results = ancestor_data_node_model.findall(
             keyword, namespace=namespace, recursive=recursive
         )
@@ -367,7 +380,13 @@ class TestDefinitionElement(object):
         choice_elem = yinsolidated.parse_json(
             {
                 "keyword": "choice",
-                "children": [{"keyword": "status", "value": "obsolete"}],
+                "children": [
+                    {
+                        "keyword": "status",
+                        "value": "obsolete",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -384,14 +403,20 @@ class TestDataDefinitionElement(object):
         choice_elem = yinsolidated.parse_json(
             {
                 "keyword": "choice",
-                "children": [{"keyword": "config", "value": "false"}],
+                "children": [
+                    {
+                        "keyword": "config",
+                        "value": "false",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
         assert not choice_elem.is_config
 
     def test_is_config_no_parent(self):
-        choice_elem = yinsolidated.parse_json({"keyword": "choice"})
+        choice_elem = yinsolidated.parse_json({"keyword": "choice",})
 
         assert choice_elem.is_config
 
@@ -399,8 +424,14 @@ class TestDataDefinitionElement(object):
         choice_elem = yinsolidated.parse_json(
             {
                 "keyword": "choice",
+                "module-prefix": "t",
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1", "t": "test:ns"},
                 "children": [
-                    {"keyword": "config", "value": "false"},
+                    {
+                        "keyword": "config",
+                        "value": "false",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                     {"keyword": "leaf"},
                 ],
             }
@@ -414,8 +445,16 @@ class TestDataDefinitionElement(object):
             {
                 "keyword": "container",
                 "children": [
-                    {"keyword": "when", "condition": "xxx"},
-                    {"keyword": "when", "condition": "yyy"},
+                    {
+                        "keyword": "when",
+                        "condition": "xxx",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "when",
+                        "condition": "yyy",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             }
         )
@@ -429,7 +468,11 @@ class TestContainerElement(object):
             {
                 "keyword": "container",
                 "children": [
-                    {"keyword": "presence", "value": "My existence is meaningful"},
+                    {
+                        "keyword": "presence",
+                        "value": "My existence is meaningful",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             }
         )
@@ -437,7 +480,7 @@ class TestContainerElement(object):
         assert container_elem.presence == "My existence is meaningful"
 
     def test_no_presence(self):
-        container_elem = yinsolidated.parse_json({"keyword": "container",})
+        container_elem = yinsolidated.parse_json({"keyword": "container"})
 
         assert container_elem.presence is None
 
@@ -445,14 +488,32 @@ class TestContainerElement(object):
 class TestLeafElement(object):
     def test_type(self):
         leaf_elem = yinsolidated.parse_json(
-            {"keyword": "leaf", "children": [{"keyword": "type", "name": "uint8"}]}
+            {
+                "keyword": "leaf",
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "uint8",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
+            }
         )
 
         assert leaf_elem.type.base_type.name == "uint8"
 
     def test_default(self):
         leaf_elem = yinsolidated.parse_json(
-            {"keyword": "leaf", "children": [{"keyword": "default", "value": "600"}]}
+            {
+                "keyword": "leaf",
+                "children": [
+                    {
+                        "keyword": "default",
+                        "value": "600",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
+            }
         )
 
         assert leaf_elem.default == "600"
@@ -464,7 +525,16 @@ class TestLeafElement(object):
 
     def test_units(self):
         leaf_elem = yinsolidated.parse_json(
-            {"keyword": "leaf", "children": [{"keyword": "units", "name": "seconds"}]}
+            {
+                "keyword": "leaf",
+                "children": [
+                    {
+                        "keyword": "units",
+                        "name": "seconds",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
+            }
         )
 
         assert leaf_elem.units == "seconds"
@@ -476,7 +546,16 @@ class TestLeafElement(object):
 
     def test_is_mandatory(self):
         leaf_elem = yinsolidated.parse_json(
-            {"keyword": "leaf", "children": [{"keyword": "mandatory", "value": "true"}]}
+            {
+                "keyword": "leaf",
+                "children": [
+                    {
+                        "keyword": "mandatory",
+                        "value": "true",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
+            }
         )
 
         assert leaf_elem.is_mandatory
@@ -485,7 +564,13 @@ class TestLeafElement(object):
         leaf_elem = yinsolidated.parse_json(
             {
                 "keyword": "leaf",
-                "children": [{"keyword": "mandatory", "value": "false"}],
+                "children": [
+                    {
+                        "keyword": "mandatory",
+                        "value": "false",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -503,8 +588,16 @@ class TestLeafElement(object):
                 "module-prefix": "t",
                 "nsmap": {"t": "test:ns"},
                 "children": [
-                    {"keyword": "key", "value": "alpha", "nsmap": {"t": "test:ns"},},
-                    {"keyword": "leaf", "name": "alpha", "nsmap": {"t": "test:ns"},},
+                    {
+                        "keyword": "key",
+                        "value": "alpha",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "leaf",
+                        "name": "alpha",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             }
         )
@@ -519,8 +612,16 @@ class TestLeafElement(object):
                 "module-prefix": "t",
                 "nsmap": {"t": "test:ns"},
                 "children": [
-                    {"keyword": "key", "value": "bravo", "nsmap": {"t": "test:ns"}},
-                    {"keyword": "leaf", "name": "alpha", "nsmap": {"t": "test:ns"}},
+                    {
+                        "keyword": "key",
+                        "value": "bravo",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "leaf",
+                        "name": "alpha",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             }
         )
@@ -529,7 +630,7 @@ class TestLeafElement(object):
         assert not leaf_elem.is_list_key
 
     def test_non_list_child_not_key(self):
-        leaf_elem = yinsolidated.parse_json({"keyword": "leaf",})
+        leaf_elem = yinsolidated.parse_json({"keyword": "leaf"})
 
         assert not leaf_elem.is_list_key
 
@@ -537,7 +638,18 @@ class TestLeafElement(object):
 class TestLeafListElement(object):
     def test_type(self):
         leaf_list_elem = yinsolidated.parse_json(
-            {"keyword": "leaf-list", "children": [{"keyword": "type", "name": "uint8"}]}
+            {
+                "keyword": "leaf-list",
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "uint8",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
+            }
         )
 
         assert leaf_list_elem.type.base_type.name == "uint8"
@@ -546,7 +658,15 @@ class TestLeafListElement(object):
         leaf_list_elem = yinsolidated.parse_json(
             {
                 "keyword": "leaf-list",
-                "children": [{"keyword": "units", "name": "seconds"}],
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "children": [
+                    {
+                        "keyword": "units",
+                        "name": "seconds",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -561,7 +681,15 @@ class TestLeafListElement(object):
         leaf_list_elem = yinsolidated.parse_json(
             {
                 "keyword": "leaf-list",
-                "children": [{"keyword": "min-elements", "value": "10"}],
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "children": [
+                    {
+                        "keyword": "min-elements",
+                        "value": "10",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -576,14 +704,30 @@ class TestLeafListElement(object):
         leaf_list_elem = yinsolidated.parse_json(
             {
                 "keyword": "leaf-list",
-                "children": [{"keyword": "max-elements", "value": "10"}],
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                "children": [
+                    {
+                        "keyword": "max-elements",
+                        "value": "10",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
         assert leaf_list_elem.max_elements == 10
 
     def test_no_max_elements(self):
-        leaf_list_elem = yinsolidated.parse_json({"keyword": "leaf-list",})
+        leaf_list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf-list",
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+            }
+        )
 
         assert leaf_list_elem.max_elements is None
 
@@ -591,14 +735,30 @@ class TestLeafListElement(object):
         leaf_list_elem = yinsolidated.parse_json(
             {
                 "keyword": "leaf-list",
-                "children": [{"keyword": "ordered-by", "value": "user"}],
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                "children": [
+                    {
+                        "keyword": "ordered-by",
+                        "value": "user",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
         assert leaf_list_elem.ordered_by == "user"
 
     def test_no_ordered_by(self):
-        leaf_list_elem = yinsolidated.parse_json({"keyword": "leaf-list",})
+        leaf_list_elem = yinsolidated.parse_json(
+            {
+                "keyword": "leaf-list",
+                "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+            }
+        )
 
         assert leaf_list_elem.ordered_by == "system"
 
@@ -613,8 +773,13 @@ class TestListElement(object):
                     {
                         "keyword": "list",
                         "nsmap": {"a": "alpha:ns", "b": "bravo:ns", "c": "charlie:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
-                            {"keyword": "key", "value": "a:alpha b:bravo charlie"},
+                            {
+                                "keyword": "key",
+                                "value": "a:alpha b:bravo charlie",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            },
                         ],
                     },
                 ],
@@ -637,7 +802,13 @@ class TestListElement(object):
         list_elem = yinsolidated.parse_json(
             {
                 "keyword": "list",
-                "children": [{"keyword": "unique", "tag": "alpha bravo charlie"},],
+                "children": [
+                    {
+                        "keyword": "unique",
+                        "tag": "alpha bravo charlie",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -647,7 +818,13 @@ class TestListElement(object):
         list_elem = yinsolidated.parse_json(
             {
                 "keyword": "list",
-                "children": [{"keyword": "min-elements", "value": "10"}],
+                "children": [
+                    {
+                        "keyword": "min-elements",
+                        "value": "10",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -662,7 +839,13 @@ class TestListElement(object):
         list_elem = yinsolidated.parse_json(
             {
                 "keyword": "list",
-                "children": [{"keyword": "max-elements", "value": "10"}],
+                "children": [
+                    {
+                        "keyword": "max-elements",
+                        "value": "10",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -677,7 +860,13 @@ class TestListElement(object):
         list_elem = yinsolidated.parse_json(
             {
                 "keyword": "list",
-                "children": [{"keyword": "ordered-by", "value": "user"}],
+                "children": [
+                    {
+                        "keyword": "ordered-by",
+                        "value": "user",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -694,7 +883,13 @@ class TestAnyxmlElement(object):
         anyxml_elem = yinsolidated.parse_json(
             {
                 "keyword": "anyxml",
-                "children": [{"keyword": "mandatory", "value": "true"}],
+                "children": [
+                    {
+                        "keyword": "mandatory",
+                        "value": "true",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -704,14 +899,20 @@ class TestAnyxmlElement(object):
         anyxml_elem = yinsolidated.parse_json(
             {
                 "keyword": "anyxml",
-                "children": [{"keyword": "mandatory", "value": "false"}],
+                "children": [
+                    {
+                        "keyword": "mandatory",
+                        "value": "false",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
         assert not anyxml_elem.is_mandatory
 
     def test_not_mandatory_implicit(self):
-        anyxml_elem = yinsolidated.parse_json({"keyword": "anyxml",})
+        anyxml_elem = yinsolidated.parse_json({"keyword": "anyxml"})
 
         assert not anyxml_elem.is_mandatory
 
@@ -729,7 +930,14 @@ class TestTypeElement(object):
                         "keyword": "type",
                         "name": "counter",
                         "nsmap": {"a": "a:ns"},
-                        "children": [{"keyword": "typedef", "name": "uint32"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "typedef",
+                                "name": "uint32",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     }
                 ],
             }
@@ -756,16 +964,23 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "percentage",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "meter",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
                                     {
                                         "keyword": "typedef",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                         "name": "meter",
                                         "children": [
-                                            {"keyword": "type", "name": "uint8"}
+                                            {
+                                                "keyword": "type",
+                                                "name": "uint8",
+                                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                            }
                                         ],
                                     }
                                 ],
@@ -787,11 +1002,19 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "test-leafref",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "leafref",
-                                "children": [{"keyword": "type", "name": "uint32"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "type",
+                                        "name": "uint32",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             }
                         ],
                     }
@@ -810,13 +1033,23 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "test-union",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "union",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "type", "name": "uint32"},
-                                    {"keyword": "type", "name": "string"},
+                                    {
+                                        "keyword": "type",
+                                        "name": "uint32",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
+                                    {
+                                        "keyword": "type",
+                                        "name": "string",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
                                 ],
                             }
                         ],
@@ -836,7 +1069,14 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "counter",
-                        "children": [{"keyword": "type", "name": "uint32"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "uint32",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     }
                 ],
             }
@@ -855,8 +1095,16 @@ class TestTypeElement(object):
                 "keyword": "type",
                 "name": "bits",
                 "children": [
-                    {"keyword": "bit", "name": "alpha"},
-                    {"keyword": "bit", "name": "bravo"},
+                    {
+                        "keyword": "bit",
+                        "name": "alpha",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "bit",
+                        "name": "bravo",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             },
         )
@@ -873,13 +1121,23 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "bits",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "bit", "name": "alpha"},
-                                    {"keyword": "bit", "name": "bravo"},
+                                    {
+                                        "keyword": "bit",
+                                        "name": "alpha",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
+                                    {
+                                        "keyword": "bit",
+                                        "name": "bravo",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
                                 ],
                             }
                         ],
@@ -897,8 +1155,16 @@ class TestTypeElement(object):
                 "keyword": "type",
                 "name": "enumeration",
                 "children": [
-                    {"keyword": "enum", "name": "alpha"},
-                    {"keyword": "enum", "name": "bravo"},
+                    {
+                        "keyword": "enum",
+                        "name": "alpha",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "enum",
+                        "name": "bravo",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             },
         )
@@ -915,13 +1181,23 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-typedef",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "enumeration",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "enum", "name": "alpha"},
-                                    {"keyword": "enum", "name": "bravo"},
+                                    {
+                                        "keyword": "enum",
+                                        "name": "alpha",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
+                                    {
+                                        "keyword": "enum",
+                                        "name": "bravo",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
                                 ],
                             }
                         ],
@@ -938,7 +1214,13 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "decimal64",
-                "children": [{"keyword": "fraction-digits", "value": "2"}],
+                "children": [
+                    {
+                        "keyword": "fraction-digits",
+                        "value": "2",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -953,12 +1235,18 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "decimal64",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "fraction-digits", "value": "2"}
+                                    {
+                                        "keyword": "fraction-digits",
+                                        "value": "2",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
                                 ],
                             },
                         ],
@@ -970,7 +1258,7 @@ class TestTypeElement(object):
         assert type_elem.fraction_digits == "2"
 
     def test_no_fraction_digits(self):
-        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"})
 
         assert type_elem.fraction_digits is None
 
@@ -979,7 +1267,13 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "identityref",
-                "children": [{"keyword": "base", "name": "base-identity"}],
+                "children": [
+                    {
+                        "keyword": "base",
+                        "name": "base-identity",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -994,12 +1288,18 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "identityref",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "base", "name": "base-identity"}
+                                    {
+                                        "keyword": "base",
+                                        "name": "base-identity",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
                                 ],
                             }
                         ],
@@ -1015,31 +1315,49 @@ class TestTypeElement(object):
             {
                 "keyword": "module",
                 "module-prefix": "t",
+                "nsmap": {"t": "test:ns"},
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                 "children": [
                     {
                         "keyword": "identity",
                         "name": "base-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                     },
                     {
                         "keyword": "identity",
                         "name": "derived-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
-                        "children": [{"keyword": "base", "name": "base-identity"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "base",
+                                "name": "base-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     },
                     {
                         "keyword": "identity",
                         "name": "nested-derived-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
-                        "children": [{"keyword": "base", "name": "derived-identity"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "base",
+                                "name": "derived-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     },
                     {
                         "keyword": "identity",
                         "name": "another-base-identity",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "module-prefix": "o",
                     },
                     {
@@ -1047,20 +1365,31 @@ class TestTypeElement(object):
                         "name": "another-derived-identity",
                         "module-prefix": "o",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
-                            {"keyword": "base", "name": "another-derived-identity"}
+                            {
+                                "keyword": "base",
+                                "name": "another-derived-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
                         ],
                     },
                     {
                         "keyword": "leaf",
                         "name": "test-leaf",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "identityref",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "base", "name": "base-identity"}
+                                    {
+                                        "keyword": "base",
+                                        "name": "base-identity",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
                                 ],
                             }
                         ],
@@ -1087,25 +1416,41 @@ class TestTypeElement(object):
                         "name": "base-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                     },
                     {
                         "keyword": "identity",
                         "name": "derived-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
-                        "children": [{"keyword": "base", "name": "base-identity"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "base",
+                                "name": "base-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     },
                     {
                         "keyword": "identity",
                         "name": "nested-derived-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
-                        "children": [{"keyword": "base", "name": "derived-identity"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "base",
+                                "name": "derived-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     },
                     {
                         "keyword": "identity",
                         "name": "another-base-identity",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "module-prefix": "o",
                     },
                     {
@@ -1113,22 +1458,30 @@ class TestTypeElement(object):
                         "name": "another-derived-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
-                            {"keyword": "base", "name": "o:another-base-identity"}
+                            {
+                                "keyword": "base",
+                                "name": "o:another-base-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
                         ],
                     },
                     {
                         "keyword": "leaf",
                         "name": "test-leaf",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "identityref",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
                                     {
                                         "keyword": "base",
                                         "name": "o:another-base-identity",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                     }
                                 ],
                             }
@@ -1145,35 +1498,44 @@ class TestTypeElement(object):
         assert len(identities) == 1
         assert identities[0].name == "another-derived-identity"
 
-        def test_missing_identity(self):
-            module_elem = yinsolidated.parse_json(
-                {
-                    "keyword": "module",
-                    "module-prefix": "t",
-                    "children": [
-                        {
-                            "keyword": "leaf",
-                            "name": "test-leaf",
-                            "children": [
-                                {
-                                    "keyword": "type",
-                                    "name": "identityref",
-                                    "children": [
-                                        {"keyword": "base", "name": "t:base-identity"}
-                                    ],
-                                }
-                            ],
-                        }
-                    ],
-                },
-            )
-            type_elem = module_elem.find("leaf").find("type")
+    def test_missing_identity(self):
+        module_elem = yinsolidated.parse_json(
+            {
+                "keyword": "module",
+                "module-prefix": "t",
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                "nsmap": {"t": "test:ns"},
+                "children": [
+                    {
+                        "keyword": "leaf",
+                        "name": "test-leaf",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "nsmap": {"t": "test:ns"},
+                        "children": [
+                            {
+                                "keyword": "type",
+                                "name": "identityref",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "base",
+                                        "name": "t:base-identity",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        type_elem = module_elem.find("leaf").find("type")
 
-            with pytest.raises(yinsolidated.MissingIdentityError):
-                type_elem.get_identities()
+        with pytest.raises(yinsolidated.MissingIdentityError):
+            type_elem.get_identities()
 
     def test_no_identities(self):
-        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"})
 
         assert len(type_elem.get_identities()) == 0
 
@@ -1182,7 +1544,13 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "string",
-                "children": [{"keyword": "length", "value": "1..253"}],
+                "children": [
+                    {
+                        "keyword": "length",
+                        "value": "1..253",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1197,11 +1565,19 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "string",
-                                "children": [{"keyword": "length", "value": "1..253"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "length",
+                                        "value": "1..253",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             },
                         ],
                     }
@@ -1215,26 +1591,32 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "fake-type",
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                 "children": [
                     {
                         "keyword": "typedef",
                         "name": "indirect-fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "another-fake-type",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
                                     {
                                         "keyword": "typedef",
                                         "name": "fake-type",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                         "children": [
                                             {
                                                 "keyword": "type",
                                                 "name": "string",
+                                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                 "children": [
                                                     {
                                                         "keyword": "length",
                                                         "value": "8..110",
+                                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                     }
                                                 ],
                                             },
@@ -1254,19 +1636,32 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "fake-type",
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                 "children": [
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "string",
-                                "children": [{"keyword": "length", "value": "1..17"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "length",
+                                        "value": "1..17",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             },
                         ],
                     },
-                    {"keyword": "length", "value": "9..17"},
+                    {
+                        "keyword": "length",
+                        "value": "9..17",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             },
         )
@@ -1283,7 +1678,14 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "leafref",
-                "children": [{"keyword": "path", "value": "/a/fake/path"}],
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                "children": [
+                    {
+                        "keyword": "path",
+                        "value": "/a/fake/path",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1294,16 +1696,23 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "fake-type",
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                 "children": [
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "leafref",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "path", "value": "/a/fake/path"}
+                                    {
+                                        "keyword": "path",
+                                        "value": "/a/fake/path",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
                                 ],
                             },
                         ],
@@ -1315,7 +1724,7 @@ class TestTypeElement(object):
         assert type_elem.path == "/a/fake/path"
 
     def test_no_path(self):
-        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"},)
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "string"})
 
         assert type_elem.path is None
 
@@ -1328,14 +1737,20 @@ class TestTypeElement(object):
                     {
                         "keyword": "pattern",
                         "value": "[a-zA-Z0-9_\\-]*",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "error-message",
                                 "value": "Must be alphanumeric",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                             }
                         ],
                     },
-                    {"keyword": "pattern", "value": ".*"},
+                    {
+                        "keyword": "pattern",
+                        "value": ".*",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             },
         )
@@ -1357,22 +1772,30 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "string",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
                                     {
                                         "keyword": "pattern",
                                         "value": "[a-zA-Z0-9_\\-]*",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                         "children": [
                                             {
                                                 "keyword": "error-message",
                                                 "value": "Must be alphanumeric",
+                                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                             }
                                         ],
                                     },
-                                    {"keyword": "pattern", "value": ".*"},
+                                    {
+                                        "keyword": "pattern",
+                                        "value": ".*",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
                                 ],
                             },
                         ],
@@ -1394,7 +1817,13 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "uint8",
-                "children": [{"keyword": "range", "value": "1..253"}],
+                "children": [
+                    {
+                        "keyword": "range",
+                        "value": "1..253",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1409,11 +1838,19 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "uint8",
-                                "children": [{"keyword": "range", "value": "1..253"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "range",
+                                        "value": "1..253",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             },
                         ],
                     }
@@ -1431,22 +1868,27 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "wrapper",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "fake-type",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
                                     {
                                         "keyword": "typedef",
                                         "name": "fake-type",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                         "children": [
                                             {
                                                 "keyword": "type",
                                                 "name": "uint8",
+                                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                 "children": [
                                                     {
                                                         "keyword": "range",
                                                         "value": "7..9",
+                                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                     }
                                                 ],
                                             },
@@ -1470,15 +1912,27 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "fake-type",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "uint8",
-                                "children": [{"keyword": "range", "value": "1..227"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "range",
+                                        "value": "1..227",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             },
                         ],
                     },
-                    {"keyword": "range", "value": "4..128"},
+                    {
+                        "keyword": "range",
+                        "value": "4..128",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             }
         )
@@ -1486,7 +1940,7 @@ class TestTypeElement(object):
         assert type_elem.range == "4..128"
 
     def test_no_range(self):
-        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "uint8"},)
+        type_elem = yinsolidated.parse_json({"keyword": "type", "name": "uint8"})
 
         assert type_elem.range is None
 
@@ -1495,7 +1949,14 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "leafref",
-                "children": [{"keyword": "type", "name": "string"}],
+                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "string",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1507,8 +1968,16 @@ class TestTypeElement(object):
                 "keyword": "type",
                 "name": "union",
                 "children": [
-                    {"keyword": "type", "name": "uint8"},
-                    {"keyword": "type", "name": "string"},
+                    {
+                        "keyword": "type",
+                        "name": "uint8",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "type",
+                        "name": "string",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             },
         )
@@ -1524,11 +1993,19 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "faketype",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "leafref",
-                                "children": [{"keyword": "type", "name": "string"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "type",
+                                        "name": "string",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             },
                         ],
                     }
@@ -1544,8 +2021,16 @@ class TestTypeElement(object):
                 "keyword": "type",
                 "name": "union",
                 "children": [
-                    {"keyword": "type", "name": "uint8"},
-                    {"keyword": "type", "name": "string"},
+                    {
+                        "keyword": "type",
+                        "name": "uint8",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
+                    {
+                        "keyword": "type",
+                        "name": "string",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    },
                 ],
             },
         )
@@ -1558,7 +2043,13 @@ class TestTypeElement(object):
             {
                 "keyword": "type",
                 "name": "leafref",
-                "children": [{"keyword": "type", "name": "uint8"}],
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "uint8",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1573,13 +2064,23 @@ class TestTypeElement(object):
                     {
                         "keyword": "typedef",
                         "name": "faketype",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "type",
                                 "name": "union",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                 "children": [
-                                    {"keyword": "type", "name": "uint8"},
-                                    {"keyword": "type", "name": "string"},
+                                    {
+                                        "keyword": "type",
+                                        "name": "uint8",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
+                                    {
+                                        "keyword": "type",
+                                        "name": "string",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    },
                                 ],
                             },
                         ],
@@ -1606,11 +2107,19 @@ class TestTypeElementWithPrefixedName(object):
                         "keyword": "type",
                         "name": "b:counter",
                         "nsmap": {"a": "a:ns", "b": "b:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
                             {
                                 "keyword": "typedef",
                                 "name": "counter",
-                                "children": [{"keyword": "type", "name": "uint32"}],
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                "children": [
+                                    {
+                                        "keyword": "type",
+                                        "name": "uint32",
+                                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                                    }
+                                ],
                             }
                         ],
                     }
@@ -1644,7 +2153,13 @@ class TestTypedefElement(object):
             {
                 "keyword": "typedef",
                 "name": "counter",
-                "children": [{"keyword": "type", "name": "uint32"}],
+                "children": [
+                    {
+                        "keyword": "type",
+                        "name": "uint32",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1655,7 +2170,13 @@ class TestTypedefElement(object):
             {
                 "keyword": "typedef",
                 "name": "counter",
-                "children": [{"keyword": "default", "value": "600"}],
+                "children": [
+                    {
+                        "keyword": "default",
+                        "value": "600",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1673,7 +2194,13 @@ class TestTypedefElement(object):
             {
                 "keyword": "typedef",
                 "name": "counter",
-                "children": [{"keyword": "units", "name": "seconds"}],
+                "children": [
+                    {
+                        "keyword": "units",
+                        "name": "seconds",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
@@ -1689,7 +2216,7 @@ class TestTypedefElement(object):
 
 class TestBitElement(object):
     def test_name(self):
-        bit_elem = yinsolidated.parse_json({"keyword": "bit", "name": "alpha"},)
+        bit_elem = yinsolidated.parse_json({"keyword": "bit", "name": "alpha"})
 
         assert bit_elem.name == "alpha"
 
@@ -1698,21 +2225,27 @@ class TestBitElement(object):
             {
                 "keyword": "bit",
                 "name": "alpha",
-                "children": [{"keyword": "position", "value": "1"}],
+                "children": [
+                    {
+                        "keyword": "position",
+                        "value": "1",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
         assert bit_elem.position == 1
 
     def test_no_position(self):
-        bit_elem = yinsolidated.parse_json({"keyword": "bit", "name": "alpha"},)
+        bit_elem = yinsolidated.parse_json({"keyword": "bit", "name": "alpha"})
 
         assert bit_elem.position is None
 
 
 class TestEnumElement(object):
     def test_name(self):
-        enum_elem = yinsolidated.parse_json({"keyword": "enum", "name": "alpha"},)
+        enum_elem = yinsolidated.parse_json({"keyword": "enum", "name": "alpha"})
 
         assert enum_elem.name == "alpha"
 
@@ -1721,14 +2254,20 @@ class TestEnumElement(object):
             {
                 "keyword": "enum",
                 "name": "alpha",
-                "children": [{"keyword": "value", "value": "1"}],
+                "children": [
+                    {
+                        "keyword": "value",
+                        "value": "1",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             },
         )
 
         assert enum_elem.value == 1
 
     def test_no_value(self):
-        enum_elem = yinsolidated.parse_json({"keyword": "enum", "name": "alpha"},)
+        enum_elem = yinsolidated.parse_json({"keyword": "enum", "name": "alpha"})
 
         assert enum_elem.value is None
 
@@ -1743,6 +2282,7 @@ class TestWhenElement(object):
                     {
                         "keyword": "when",
                         "condition": "t:foo = 'bar'",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "nsmap": {"t": "test:ns"},
                     }
                 ],
@@ -1762,6 +2302,7 @@ class TestWhenElement(object):
                     {
                         "keyword": "when",
                         "condition": "../foo/bar = 'alpha' | /t:root/test = 'bravo'",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "nsmap": {"t": "test:ns", "d": "default:ns"},
                     }
                 ],
@@ -1777,7 +2318,7 @@ class TestWhenElement(object):
         assert when_element.nsmap == {"d": "default:ns", "t": "test:ns"}
 
     def test_self_context(self):
-        when_element = yinsolidated.parse_json({"keyword": "when"},)
+        when_element = yinsolidated.parse_json({"keyword": "when"})
 
         assert not when_element.context_node_is_parent
 
@@ -1835,7 +2376,13 @@ class TestIdentityElement(object):
                 "name": "test-identity",
                 "module-prefix": "t",
                 "nsmap": {"t": "test:ns"},
-                "children": [{"keyword": "base", "name": "base-identity"}],
+                "children": [
+                    {
+                        "keyword": "base",
+                        "name": "base-identity",
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                    }
+                ],
             }
         )
 
@@ -1848,7 +2395,13 @@ class TestIdentityElement(object):
                     "name": "test-identity",
                     "module-prefix": "t",
                     "nsmap": {"t": "test:ns", "o": "other:ns"},
-                    "children": [{"keyword": "base", "name": "o:base-identity"}],
+                    "children": [
+                        {
+                            "keyword": "base",
+                            "name": "o:base-identity",
+                            "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        }
+                    ],
                 },
             )
 
@@ -1864,27 +2417,41 @@ class TestIdentityElement(object):
                         "name": "base-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                     },
                     {
                         "keyword": "identity",
                         "name": "derived-identity-1",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns"},
-                        "children": [{"keyword": "base", "name": "base-identity"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "base",
+                                "name": "base-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     },
                     {
                         "keyword": "identity",
                         "name": "another-base-identity",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                     },
                     {
                         "keyword": "identity",
                         "name": "derived-identity-2",
                         "module-prefix": "t",
                         "nsmap": {"t": "test:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
-                            {"keyword": "base", "name": "another-base-identity"}
+                            {
+                                "keyword": "base",
+                                "name": "another-base-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
                         ],
                     },
                     {
@@ -1892,15 +2459,27 @@ class TestIdentityElement(object):
                         "name": "external-derived-identity",
                         "module-prefix": "o",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
-                        "children": [{"keyword": "base", "name": "t:base-identity"}],
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                        "children": [
+                            {
+                                "keyword": "base",
+                                "name": "t:base-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
+                        ],
                     },
                     {
                         "keyword": "identity",
                         "name": "nested-derived-identity",
                         "module-prefix": "o",
                         "nsmap": {"t": "test:ns", "o": "other:ns"},
+                        "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                         "children": [
-                            {"keyword": "base", "name": "o:external-derived-identity"}
+                            {
+                                "keyword": "base",
+                                "name": "o:external-derived-identity",
+                                "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
+                            }
                         ],
                     },
                 ],

--- a/test/json_parser_test.py
+++ b/test/json_parser_test.py
@@ -20,15 +20,8 @@ class TestYinElement(object):
             {
                 "keyword": "module",
                 "module-prefix": "t",
-                "children": [
-                    {
-                        "keyword": "choice",
-                        "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
-                            "t": "test:ns",
-                        },
-                    }
-                ],
+                "nsmap": {"yin": "urn:ietf:params:xml:ns:yang:yin:1", "t": "test:ns"},
+                "children": [{"keyword": "choice"}],
             }
         )
         choice_elem = module_elem.find("choice")
@@ -49,20 +42,8 @@ class TestYinElement(object):
                     {
                         "keyword": "test-container",
                         "module-prefix": "in",
-                        "nsmap": {
-                            "yin": "urn:ietf:params:xml:ns:yang:yin:1",
-                            "in": "inner:ns",
-                        },
-                        "children": [
-                            {
-                                "keyword": "choice",
-                                "namespace": "inner:ns",
-                                "nsmap": {
-                                    "yin": "urn:ietf:params:xml:ns:yang:yin:1",
-                                    "in": "inner:ns",
-                                },
-                            }
-                        ],
+                        "nsmap": {"in": "inner:ns",},
+                        "children": [{"keyword": "choice"}],
                     }
                 ],
             }
@@ -1694,7 +1675,7 @@ class TestWhenElement(object):
         when_element = container_elem.find("when")
 
         assert when_element.condition == "t:foo = 'bar'"
-        assert when_element.namespace_map == {"t": "test:ns"}
+        assert when_element.nsmap == {"t": "test:ns"}
 
     def test_prefix_added(self):
         container_elem = yinsolidated.parse_json(
@@ -1717,7 +1698,7 @@ class TestWhenElement(object):
             "../d:foo/d:bar = 'alpha' | /t:root/d:test = 'bravo'"
         )
 
-        assert when_element.namespace_map == {"d": "default:ns", "t": "test:ns"}
+        assert when_element.nsmap == {"d": "default:ns", "t": "test:ns"}
 
     def test_self_context(self):
         when_element = yinsolidated.parse_json({"keyword": "when"},)

--- a/yinsolidated/__init__.py
+++ b/yinsolidated/__init__.py
@@ -5,7 +5,12 @@
 # pylint: disable=wildcard-import,unused-wildcard-import
 
 # Forward module definitions
-from yinsolidated._error import Error, MissingModuleNameError, MissingPrefixError
+from yinsolidated._error import (
+    Error,
+    MissingIdentityError,
+    MissingModuleNameError,
+    MissingPrefixError,
+)
 from yinsolidated._version import __version__
 from yinsolidated.json_parser import parse as parse_json
 from yinsolidated.parser import *

--- a/yinsolidated/_error.py
+++ b/yinsolidated/_error.py
@@ -32,3 +32,11 @@ class MissingModuleNameError(_MissingAttributeError):
 
     def __init__(self, data_def_element):
         super(MissingModuleNameError, self).__init__("module-name", data_def_element)
+
+
+class MissingNamespaceError(_MissingAttributeError):
+
+    """Could not find namespace attribute"""
+
+    def __init__(self, data_def_element):
+        super(MissingNamespaceError, self).__init__("namespace", data_def_element)

--- a/yinsolidated/_error.py
+++ b/yinsolidated/_error.py
@@ -40,3 +40,10 @@ class MissingNamespaceError(_MissingAttributeError):
 
     def __init__(self, data_def_element):
         super(MissingNamespaceError, self).__init__("namespace", data_def_element)
+
+
+class MissingIdentityError(Error):
+    def __init__(self, name, namespace):
+        super(MissingIdentityError, self).__init__(
+            "Could not find identity {} in namespace {}".format(name, namespace)
+        )

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/yinsolidated/json_parser.py
+++ b/yinsolidated/json_parser.py
@@ -94,6 +94,13 @@ class YinElement(dict):
         return self.get("nsmap") or {}
 
     @property
+    def namespace_map(self):
+        nsmap = {}
+        for element in self.iter_parents(include_self=True):
+            nsmap.update(element.nsmap)
+        return nsmap
+
+    @property
     def namespace(self):
         prefix = self.prefix
         for element in self.iter_parents(include_self=True):
@@ -480,7 +487,7 @@ class TypeElement(YinElement):
         data_node = self.getparent()
 
         identifier_to_find = _parse_identifier(
-            identity, data_node.nsmap, data_node.namespace
+            identity, data_node.namespace_map, data_node.namespace
         )
 
         for identity_elem in root.iterfind("identity", namespace=_YIN):
@@ -578,7 +585,9 @@ class IdentityElement(YinElement):
             name = None
             namespace = None
         else:
-            name, namespace = _parse_identifier(base, self.nsmap, self.namespace)
+            name, namespace = _parse_identifier(
+                base, self.namespace_map, self.namespace
+            )
 
         return name, namespace
 

--- a/yinsolidated/json_parser.py
+++ b/yinsolidated/json_parser.py
@@ -31,7 +31,7 @@ def parse(contents):
 
 def _parse(raw, parent=None):
     if not isinstance(raw, dict):
-        raise Error(
+        raise _error.Error(
             "expected dict, got {type}: {value}".format(type=type(raw), value=raw)
         )
     cls = _get_yin_element_class(raw.get("keyword"))
@@ -491,13 +491,6 @@ def _parse_identifier(identifier, nsmap, default_namespace):
         namespace = default_namespace
 
     return name, namespace
-
-
-class MissingIdentityError(Error):
-    def __init__(self, name, namespace):
-        super(MissingIdentityError, self).__init__(
-            "Could not find identity {} in namespace {}".format(name, namespace)
-        )
 
 
 class TypedefElement(YinElement):

--- a/yinsolidated/parser.py
+++ b/yinsolidated/parser.py
@@ -27,11 +27,6 @@ _DATA_NODE_PREDICATE = " or ".join(
 )
 
 
-class Error(Exception):
-
-    """Base exception"""
-
-
 class _ConsolidatedModelLookup(etree.CustomElementClassLookup):
     def lookup(self, _node_type, _document, namespace, name):
         return _get_yin_element_class(name) if namespace == _common.YIN_NS else None
@@ -451,7 +446,7 @@ class TypeElement(YinElement):
             if identifier == identifier_to_find:
                 return identity_elem
 
-        raise MissingIdentityError(*identifier_to_find)
+        raise _error.MissingIdentityError(*identifier_to_find)
 
 
 def _parse_identifier(identifier, nsmap, default_namespace):
@@ -463,13 +458,6 @@ def _parse_identifier(identifier, nsmap, default_namespace):
         namespace = default_namespace
 
     return name, namespace
-
-
-class MissingIdentityError(Error):
-    def __init__(self, name, namespace):
-        super(MissingIdentityError, self).__init__(
-            "Could not find identity {} in namespace {}".format(name, namespace)
-        )
 
 
 class TypedefElement(YinElement):

--- a/yinsolidated/plugin/plugin.py
+++ b/yinsolidated/plugin/plugin.py
@@ -102,11 +102,12 @@ def _make_builtin_yin_element(statement, parent_elem, fmt):
 
     module_name = None
     module_prefix = None
-    nsmap = {"yin": yin_parser.yin_namespace}
+    nsmap = {}
 
     if statement.keyword == "module":
         module_name = statement.i_modulename
         module_prefix = statement.i_prefix
+        nsmap["yin"] = yin_parser.yin_namespace
         nsmap.update(_get_module_nsmap(statement))
     elif _is_augmenting_another_module(statement) or statement.keyword == "identity":
         module_name = statement.i_module.i_modulename
@@ -147,12 +148,14 @@ def _make_builtin_yin_element(statement, parent_elem, fmt):
 
 
 class _JsonElement(dict):
-    def __init__(self, *args, **kwargs):
-        parent_elem = kwargs.pop("parent_elem", None)
-        super(_JsonElement, self).__init__(*args, **kwargs)
+    def __init__(self, keyword, namespace, nsmap, parent_elem):
+        super(_JsonElement, self).__init__(keyword=keyword, namespace=namespace)
 
         if parent_elem is not None:
             parent_elem["children"].append(self)
+
+        if nsmap:
+            self["nsmap"] = nsmap
 
     @property
     def text(self):


### PR DESCRIPTION
Similar to an XML tree, rather than storing the full namespace map on
each node, look for prefixes by walking up the parents.

Also don't set "nsmap" key for each *yin_element* which reduces the
duplication.