### PR TITLE
Yield all child elements that are data nodes.

### DIFF
--- a/test/json_parser_test.py
+++ b/test/json_parser_test.py
@@ -216,6 +216,7 @@ def ancestor_data_node_model():
                                             "children": [
                                                 {
                                                     "keyword": "leaf",
+                                                    "name": "test-leaf",
                                                     "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                     "children": [
                                                         {
@@ -233,6 +234,7 @@ def ancestor_data_node_model():
                                             "children": [
                                                 {
                                                     "keyword": "leaf-list",
+                                                    "name": "test-leaf-list",
                                                     "namespace": "urn:ietf:params:xml:ns:yang:yin:1",
                                                     "children": [
                                                         {
@@ -361,6 +363,25 @@ class TestFind(object):
         )
 
         assert len(results) == expected_count
+
+
+class TestIterateDataNodes(object):
+    def test_direct_child(self, ancestor_data_node_model):
+        container_elem = ancestor_data_node_model.find("container")
+        names = [data_node.name for data_node in container_elem.iterate_data_nodes()]
+        assert names == ["test-list"]
+
+    def test_not_direct_children(self, ancestor_data_node_model):
+        list_elem = ancestor_data_node_model.find("container").find("list")
+        names = [data_node.name for data_node in list_elem.iterate_data_nodes()]
+        assert names == ["test-leaf", "test-leaf-list", "nested-container"]
+
+    def test_iterate_module(self, ancestor_data_node_model):
+        names = [
+            data_node.name
+            for data_node in ancestor_data_node_model.iterate_data_nodes()
+        ]
+        assert names == ["test-container", "sibling-list", "sibling-container"]
 
 
 class TestModuleElement(object):

--- a/test/plugin_json_test.py
+++ b/test/plugin_json_test.py
@@ -45,7 +45,7 @@ def consolidated_model():
 
     consolidated_model_json = subprocess.check_output(pyang_command)
 
-    return json.loads(consolidated_model_json)
+    return json.loads(consolidated_model_json.decode("utf-8"))
 
 
 def get_nested(yin_element, *path):

--- a/yinsolidated/_version.py
+++ b/yinsolidated/_version.py
@@ -2,4 +2,4 @@
 
 """Yinsolidated version"""
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"

--- a/yinsolidated/json_parser.py
+++ b/yinsolidated/json_parser.py
@@ -215,7 +215,19 @@ def _change_all_whitespace_to_spaces(string):
 
 
 class ModuleElement(YinElement):
-    pass
+    def iterate_data_nodes(self):
+        for data_node in _iterate_data_node(self):
+            yield data_node
+
+
+def _iterate_data_node(parent):
+    for yin_element in parent.children:
+        if _common.is_data_node(yin_element.keyword):
+            yield yin_element
+        elif _common.is_data_definition(yin_element.keyword):
+            for child in yin_element.children:
+                for data_node in _iterate_data_node(child):
+                    yield data_node
 
 
 class DefinitionElement(YinElement):
@@ -243,6 +255,10 @@ class ContainerElement(DataDefinitionElement):
     @property
     def presence(self):
         return _get_subelem_attribute_or_default(self, "presence", "value")
+
+    def iterate_data_nodes(self):
+        for data_node in _iterate_data_node(self):
+            yield data_node
 
 
 def _get_subelem_attribute_or_default(
@@ -379,6 +395,10 @@ class ListElement(DataDefinitionElement):
     @property
     def ordered_by(self):
         return _get_ordered_by(self)
+
+    def iterate_data_nodes(self):
+        for data_node in _iterate_data_node(self):
+            yield data_node
 
 
 class AnyxmlElement(DataDefinitionElement):


### PR DESCRIPTION
*iterate_data_nodes* is a method we've had on our internal datamodel class since forever. There's no reason not to have it directly in YINsolidated to make walking the model easier.